### PR TITLE
Makefile: fix clang compilation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ EXTRA_DIST = \
 
 SUBDIRS = include lib tests
 
-AM_CXXFLAGS = -fcoroutines -std=c++20
+AM_CXXFLAGS = -std=c++20
 
 sbin_PROGRAMS = ublk ublk_user_id
 noinst_PROGRAMS = demo_null demo_event

--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,15 @@ AX_PTHREAD
 dnl Check for C++.
 AC_PROG_CXX
 
+AS_CASE([$CXX],
+  [*clang++*], [ENABLE_CORO_FLAG=""],
+  [*g++*], [ENABLE_CORO_FLAG="-fcoroutines"],
+  [ENABLE_CORO_FLAG=""]
+)
+
+CXXFLAGS="$CXXFLAGS $ENABLE_CORO_FLAG"
+
+
 dnl --enable-gcc-warnings to turn on GCC warnings (for developers).
 AC_ARG_ENABLE([gcc-warnings],
     [AS_HELP_STRING([--enable-gcc-warnings],


### PR DESCRIPTION
Hello! I have been testing ublksrv with clang compiler, and lost some time trying to understand how to pass proper flags with autotools. This PR contains small fix for the issue. I have tested changes with g++-10, g++-11, g++-12 and clang++-14 up to clang++-16. Unit tests complete successfully.

I am open to any comments concerning this MR and will fix problems, if any.

-------------------------------------

clang/clang++ can compile ublksrv sources, but it doesn't support '-fcoroutines' flag, which is mandatory for older versions of g++ to compile sources with c++20 coroutines support.

This commit changes Makefile.am and configure.ac, in such way, one can build ublksrv sources using clang++.

After selecting c++ compiler, configure script will match $CXX with clang++ or g++, flag -fcoroutines will be added to CXXFLAGS only when building with g++. Order of match strings in AS_CASE is important, because `*g++*` string includes `*clang++*`, thus we must check with longer string first.