### PR TITLE
ublksrv_tgt: add support for UBLK_F_USER_RECOVERY_FAIL_IO

### DIFF
--- a/include/ublk_cmd.h
+++ b/include/ublk_cmd.h
@@ -53,7 +53,7 @@
 	_IOR('u', 0x14, struct ublksrv_ctrl_cmd)
 
 /*
- * 64bit are enough now, and it should be easy to extend in case of
+ * 64bits are enough now, and it should be easy to extend in case of
  * running out of feature flags
  */
 #define UBLK_FEATURES_LEN  8
@@ -147,8 +147,18 @@
  */
 #define UBLK_F_NEED_GET_DATA (1UL << 2)
 
+/*
+ * - Block devices are recoverable if ublk server exits and restarts
+ * - Outstanding I/O when ublk server exits is met with errors
+ * - I/O issued while there is no ublk server queues
+ */
 #define UBLK_F_USER_RECOVERY	(1UL << 3)
 
+/*
+ * - Block devices are recoverable if ublk server exits and restarts
+ * - Outstanding I/O when ublk server exits is reissued
+ * - I/O issued while there is no ublk server queues
+ */
 #define UBLK_F_USER_RECOVERY_REISSUE	(1UL << 4)
 
 /*
@@ -184,11 +194,18 @@
  */
 #define UBLK_F_ZONED (1ULL << 8)
 
+/*
+ * - Block devices are recoverable if ublk server exits and restarts
+ * - Outstanding I/O when ublk server exits is met with errors
+ * - I/O issued while there is no ublk server is met with errors
+ */
+#define UBLK_F_USER_RECOVERY_FAIL_IO (1ULL << 9)
 
 /* device state */
 #define UBLK_S_DEV_DEAD	0
 #define UBLK_S_DEV_LIVE	1
 #define UBLK_S_DEV_QUIESCED	2
+#define UBLK_S_DEV_FAIL_IO 	3
 
 /* shipped via sqe->cmd of io_uring command */
 struct ublksrv_ctrl_cmd {

--- a/lib/ublksrv_cmd.c
+++ b/lib/ublksrv_cmd.c
@@ -438,6 +438,8 @@ static const char *ublksrv_dev_state_desc(struct ublksrv_ctrl_dev *dev)
 		return "LIVE";
 	case UBLK_S_DEV_QUIESCED:
 		return "QUIESCED";
+	case UBLK_S_DEV_FAIL_IO:
+		return "FAIL_IO";
 	default:
 		return "UNKNOWN";
 	};

--- a/nbd/tgt_nbd.cpp
+++ b/nbd/tgt_nbd.cpp
@@ -808,7 +808,6 @@ static int nbd_setup_tgt(struct ublksrv_dev *dev, int type, bool recovery,
 
 	ublk_assert(jbuf);
 	ublk_assert(type == UBLKSRV_TGT_TYPE_NBD);
-	ublk_assert(!recovery || info->state == UBLK_S_DEV_QUIESCED);
 
 	ublksrv_json_read_target_str_info(jbuf, NBD_MAX_NAME, "host",
 			host_name);

--- a/qcow2/tgt_qcow2.cpp
+++ b/qcow2/tgt_qcow2.cpp
@@ -146,7 +146,6 @@ static int qcow2_recovery_tgt(struct ublksrv_dev *dev, int type)
 	int tgt_depth;
 
 	ublk_assert(jbuf);
-	ublk_assert(info->state == UBLK_S_DEV_QUIESCED);
 	ublk_assert(type == UBLKSRV_TGT_TYPE_QCOW2);
 
 	/* qcow2 doesn't support user copy yet */

--- a/tests/generic/007
+++ b/tests/generic/007
@@ -1,0 +1,163 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
+
+. common/fio_common
+
+echo -e "\ttest nosrv (state after ublk server is killed) and recovery behavior"
+echo -e "\tfor all valid recovery options"
+echo
+
+DD_PID=0
+
+# submit an I/O async and store pid into DD_PID
+submit_io()
+{
+	dd if=$1 of=/dev/null iflag=direct count=1 bs=4k 2>/dev/null &
+	DD_PID=$!
+}
+
+# check the status of the I/O issued by DD_PID
+# 0 - I/O succeeded
+# 1 - I/O error
+# 2 - I/O queued
+check_io_status()
+{
+	sleep 1
+	# if process is still alive after 1 second, I/O is likely queued
+	if ps -p $DD_PID > /dev/null 2>/dev/null; then
+		return 2
+	else
+		if wait $DD_PID; then return 0; else return 1; fi
+	fi
+}
+
+del_dev()
+{
+	sleep 2
+	RES=`__remove_ublk_dev_return $1`
+	if [ $RES -ne 0 ]; then
+		echo -e "\t\tdelete $1 failed"
+		return 1
+	fi
+	wait
+	sleep 3
+}
+
+ublk_run_recovery_test()
+{
+	export T_TYPE_PARAMS="-t null -r $RECOVERY -i $RECOVERY_REISSUE -e $RECOVERY_FAIL_IO"
+	echo -e "\trunning with params: $T_TYPE_PARAMS"
+	DEV=`__create_ublk_dev`
+
+	echo -e "\t\tcheck behavior before nosrv - expect no error"
+	submit_io $DEV
+	check_io_status
+	RES=$?
+	if [ $RES -ne 0 ]; then
+		echo -e "\t\tI/O error while ublk server still up!"
+		return 1
+	fi
+
+	pid1=`__ublk_get_pid $DEV`
+	kill -9 $pid1
+	sleep 2
+	echo -ne "\t\tcheck behavior during nosrv - "
+	submit_io $DEV
+	check_io_status
+	RES=$?
+	if [ $RECOVERY_FAIL_IO -ne 0 ]; then
+		echo "expect I/O error"
+		if [ $RES -ne 1 ]; then
+			echo -e "\t\tincorrect nosrv behavior!"
+			echo -e "\t\texpected io error, got $RES"
+			return 1
+		fi
+	elif [ $RECOVERY -ne 0 ]; then
+		echo "expect I/O queued"
+		if [ $RES -ne 2 ]; then
+			echo -e "\t\tincorrect nosrv behavior!"
+			echo -e "\t\texpected queued io, got $RES"
+			return 1
+		fi
+	else
+		echo "expect I/O error" # because device should be gone
+		if [ $RES -ne 1 ]; then
+			echo -e "\t\tincorrect nosrv behavior!"
+			echo -e "\t\texpected io error, got $RES"
+			return 1
+		fi
+	fi
+
+	echo -e "\t\ttry to recover the device"
+	secs=0
+	while [ $secs -lt 10 ]; do
+		RES=`__recover_ublk_dev $DEV`
+		[ $RES -eq 0 ] && break
+		sleep 1
+		let secs++
+	done
+	if [ $RES -ne 0 ]; then
+		echo -e "\t\tfailed to recover device!"
+		if [ $RECOVERY -ne 0 ]; then
+			return 1
+		else
+			echo -e "\t\tforgiving expected recovery failure"
+			del_dev $DEV
+			echo
+			return 0
+		fi
+	else
+		if [ $RECOVERY -eq 0 ]; then
+			echo -e "\t\trecovery unexpectedly succeeded!"
+			return 1
+		fi
+	fi
+
+	# if I/O queued before, make sure it completes now
+	if [ $RECOVERY_FAIL_IO -eq 0 ] && [ $RECOVERY -ne 0 ]; then
+		echo -e "\t\tchecking that I/O completed after recovery"
+		check_io_status
+		RES=$?
+		if [ $RES -ne 0 ]; then
+			echo -e "\t\tpreviously queued I/O did not succeed!"
+			echo -e "\t\texpected success got $RES"
+			return 1
+		fi
+	fi
+
+	echo -e "\t\tcheck behavior after recovery - expect no error"
+	submit_io $DEV
+	check_io_status
+	RES=$?
+	if [ $RES -ne 0 ]; then
+		echo -e "\t\tI/O error after recovery!"
+		return 1
+	fi
+
+	# cleanup
+	pid2=`__ublk_get_pid $DEV`
+	kill -9 $pid2
+	del_dev $DEV
+
+	echo
+}
+
+RECOVERY=0
+RECOVERY_REISSUE=0
+RECOVERY_FAIL_IO=0
+ublk_run_recovery_test
+
+RECOVERY=1
+RECOVERY_REISSUE=0
+RECOVERY_FAIL_IO=0
+ublk_run_recovery_test
+
+RECOVERY=1
+RECOVERY_REISSUE=1
+RECOVERY_FAIL_IO=0
+ublk_run_recovery_test
+
+RECOVERY=1
+RECOVERY_REISSUE=0
+RECOVERY_FAIL_IO=1
+ublk_run_recovery_test

--- a/tgt_loop.cpp
+++ b/tgt_loop.cpp
@@ -99,7 +99,6 @@ static int loop_recovery_tgt(struct ublksrv_dev *dev, int type)
 	const char *jbuf = ublksrv_ctrl_get_recovery_jbuf(cdev);
 
 	ublk_assert(type == UBLKSRV_TGT_TYPE_LOOP);
-	ublk_assert(info->state == UBLK_S_DEV_QUIESCED);
 
 	return loop_setup_tgt(dev, type, true, jbuf);
 }

--- a/tgt_null.cpp
+++ b/tgt_null.cpp
@@ -56,7 +56,6 @@ static int null_recovery_tgt(struct ublksrv_dev *dev, int type)
 	struct ublk_params p;
 
 	ublk_assert(jbuf);
-	ublk_assert(info->state == UBLK_S_DEV_QUIESCED);
 	ublk_assert(type == UBLKSRV_TGT_TYPE_NULL);
 
 	ret = ublksrv_json_read_params(&p, jbuf);


### PR DESCRIPTION
A new recovery flag, UBLK_F_USER_RECOVERY_FAIL_IO, is being added to ublk_drv at

https://lore.kernel.org/linux-block/20240917002155.2044225-1-ushankar@purestorage.com/

Support the creation of devices with this flag specified (via a new -e flag for ublk add). Add a test to verify that all recovery flag combinations have the expected behavior.