### PR TITLE
Add macros UBLK_CONTROL and UBLKC_PREFIX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,6 +153,24 @@ else
   AC_MSG_RESULT([no])
 fi
 
+ublk_control=/dev/ublk-control
+AC_ARG_WITH(
+  [ublk_control],
+  [AS_HELP_STRING([--with-ublk_control], [Set the ublk control device. Defaults to /dev/ublk-control.])],
+  [ublk_control="$withval"]
+  [],
+)
+AC_DEFINE_UNQUOTED([UBLK_CONTROL], ["${ublk_control}"], [ublk control device.])
+
+ublkc_prefix=/dev
+AC_ARG_WITH(
+  [ublkc_prefix],
+  [AS_HELP_STRING([--with-ublkc_prefix], [Set the directory prefix for ublkc devices. Defaults to /dev.])],
+  [ublkc_prefix="$withval"]
+  [],
+)
+AC_DEFINE_UNQUOTED([UBLKC_PREFIX], ["${ublkc_prefix}"], [prefix for ublkc devices.])
+
 AC_CHECK_PROGS([DOXYGEN], [doxygen])
 if test -z "$DOXYGEN"; then
    AC_MSG_WARN([Doxygen not found - continue without Doxygen support])

--- a/include/ublksrv_priv.h
+++ b/include/ublksrv_priv.h
@@ -26,7 +26,11 @@
 
 
 /* todo: relace the hardcode name with /dev/char/maj:min */
-#define UBLKC_DEV	"/dev/ublkc"
+#ifdef UBLKC_PREFIX
+#define	UBLKC_DEV	UBLKC_PREFIX "/ublkc"
+#else
+#define	UBLKC_DEV	"/dev/ublkc"
+#endif
 #define UBLKC_PATH_MAX	32
 
 #ifdef __cplusplus

--- a/lib/ublksrv_cmd.c
+++ b/lib/ublksrv_cmd.c
@@ -4,7 +4,11 @@
 
 #include "ublksrv_priv.h"
 
+#ifdef UBLK_CONTROL
+#define	CTRL_DEV	UBLK_CONTROL
+#else
 #define	CTRL_DEV	"/dev/ublk-control"
+#endif
 
 #define CTRL_CMD_HAS_DATA	1
 #define CTRL_CMD_HAS_BUF	2


### PR DESCRIPTION
Some users might mount devtmpfs to a location other than /dev.
This means the /dev/ublk-control device might exist at a different
location on the filesystem.

Similarly /dev/ublkc[0-9] devices might exist in different places.

The macros UBLK_CONTROL and UBLKC_PREFIX configure the locations of
these devices. UBLK_CONTROL is the full name of the control device,
and UBLKC_PREFIX is the parent directory of all ublkc[0-9] devices.

Fixes #74 