### PR TITLE
Handle interrupts in __ublksrv_ctrl_cmd

### DIFF
--- a/lib/ublksrv_cmd.c
+++ b/lib/ublksrv_cmd.c
@@ -123,7 +123,9 @@ static int __ublksrv_ctrl_cmd(struct ublksrv_ctrl_dev *dev,
 		return ret;
 	}
 
-	ret = io_uring_wait_cqe(&dev->ring, &cqe);
+	do {
+		ret = io_uring_wait_cqe(&dev->ring, &cqe);
+	} while (ret == -EINTR);
 	if (ret < 0) {
 		fprintf(stderr, "wait cqe: %s\n", strerror(-ret));
 		return ret;


### PR DESCRIPTION
The syscall [`io_uring_enter`](https://manpages.debian.org/unstable/liburing-dev/io_uring_enter.2.en.html) may return EINTR if it is interrupted by a delivery of a signal.  This was happening to me recently; I saw that the `SIG_PROF` signal fired periodically, which would fail the `ublksrv_ctrl_start_dev()` call (returns -EINTR). The signal is firing due to unrelated circumstances. 

Since __ublksrv_ctrl_cmd already added an SQE, it's easier for ublksrv to handle the error instead of the caller.

Note that I only added support to `__ublksrv_ctrl_cmd` since control commands are likely to be done once on startup. io_urings for handling IO are already expected to loop for IO, so there's no need for ublksrv to explicitly handle the `EINTR`.

Currently the code loops indefinitely. I'm also considering it best practice to set some maximum retry number or timeout, but I wanted to get your opinion first.

Also I thought about using [`TEMP_FAILURE_RETRY`](https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html) but the semantics from `io_uring_wait_cqe` are a bit different. `TEMP_FAILURE_RETRY` expects the return code to be `-1` and then checks `errno`, but `io_uring_wait_cqe` returns -EINTR directly, so the do while loop is necessary.