### PR TITLE
Make ublksrv_reap_events_uring public

### DIFF
--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -912,6 +912,14 @@ extern int ublksrv_process_io(const struct ublksrv_queue *q);
  * @param res io result
  */
 extern int ublksrv_complete_io(const struct ublksrv_queue *q, unsigned tag, int res);
+
+/**
+ * Reap events received from queue
+ *
+ * @param tq the pointer for ublksrv_queue
+ */
+extern int ublksrv_queue_reap_events(struct ublksrv_queue *tq);
+
 /** @} */ // end of ublksrv_queue group
 
 #ifdef __cplusplus

--- a/lib/ublksrv.c
+++ b/lib/ublksrv.c
@@ -858,6 +858,13 @@ static int ublksrv_reap_events_uring(struct io_uring *r)
 	return count;
 }
 
+int ublksrv_queue_reap_events(struct ublksrv_queue *tq)
+{
+	if (tq->ring_ptr)
+		return ublksrv_reap_events_uring(tq->ring_ptr);
+	return -1;
+}
+
 static void ublksrv_queue_discard_io_pages(struct _ublksrv_queue *q)
 {
 	const struct ublksrv_ctrl_dev *cdev = q->dev->ctrl_dev;


### PR DESCRIPTION
Make this symbol public. I need it for an app that calls directly to /lib64/libublksrv.so