### PR TITLE
change handle_io_async return type to void

### DIFF
--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -186,6 +186,9 @@ struct ublksrv_tgt_type {
 	 * has to be implemented. Otherwise, target can implement
 	 * ->handle_event() for processing io completion there.
 	 *
+	 * The return value is not checked. The user is responsible for handling
+	 * any failure.
+	 *
 	 *  Required.
 	 */
 	int (*handle_io_async)(const struct ublksrv_queue *,


### PR DESCRIPTION
The return value is never checked. Invocations of handle_io_async are expected to call ublksrv_complete_io even in an error occurred, so it's cleaner if that responsibility stays with the target in every case.

Returning void also matches the similar function `submit_bio()` in the kernel.

Fixes #81 