### PR TITLE
ublksrv_queue_reap_events: fix signature and use the correct ring

### DIFF
--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -918,7 +918,7 @@ extern int ublksrv_complete_io(const struct ublksrv_queue *q, unsigned tag, int 
  *
  * @param tq the pointer for ublksrv_queue
  */
-extern int ublksrv_queue_reap_events(struct ublksrv_queue *tq);
+extern int ublksrv_queue_reap_events(const struct ublksrv_queue *tq);
 
 /** @} */ // end of ublksrv_queue group
 

--- a/lib/ublksrv.c
+++ b/lib/ublksrv.c
@@ -858,11 +858,9 @@ static int ublksrv_reap_events_uring(struct io_uring *r)
 	return count;
 }
 
-int ublksrv_queue_reap_events(struct ublksrv_queue *tq)
+int ublksrv_queue_reap_events(const struct ublksrv_queue *tq)
 {
-	if (tq->ring_ptr)
-		return ublksrv_reap_events_uring(tq->ring_ptr);
-	return -1;
+	return ublksrv_reap_events_uring(&tq_to_local(tq)->ring);
 }
 
 static void ublksrv_queue_discard_io_pages(struct _ublksrv_queue *q)


### PR DESCRIPTION
There was a bug in the previous patch that used the wrong ring, additionally did not use const in the function signature
causing compiler warnings.

This patch has been verified to work with my application and compile without warnings.