### PR TITLE
list_one_dev: do not call ublksrv_json_dump with no buffer

### DIFF
--- a/ublksrv_tgt.cpp
+++ b/ublksrv_tgt.cpp
@@ -985,7 +985,7 @@ static int list_one_dev(int number, bool log, bool verbose)
 	} else {
 		const char *buf = ublksrv_tgt_get_dev_data(dev);
 
-		if (verbose)
+		if (verbose && buf)
 			ublksrv_json_dump(buf);
 		else
 			ublksrv_ctrl_dump(dev, buf);


### PR DESCRIPTION
Only targets spawned by "ublk add -t ..." will have a pid-file containing the json buffer for its configuration.
So when creating a different type of target, like ./demo_null, ublksrv_tgt_store_dev_data() is never invoked and thus the buffer in list_one_dev is null and we segfault inside ublksrv_json_dump.

For now, only call into ublksrv_json_dump iff -v is used and we have a buffer else fall-back to ublksrv_ctrl_dump which can handle the json buffer being NULL.

In the future we should move ublksrv_tgt_store_dev_data and ublksrv_tgt_get_dev_data into the public library so that all targets can store the json buffer like the built-in ones can.

To reproduce:
Start a demo_null target then run "ublk list -v" and it will crash.