### PR TITLE
Make demo_null update the pid_file with the parameters

### DIFF
--- a/demo_null.c
+++ b/demo_null.c
@@ -57,6 +57,7 @@ static void *demo_null_io_handler_fn(void *data)
 	pthread_mutex_lock(&jbuf_lock);
 	ublksrv_json_write_queue_info(ublksrv_get_ctrl_dev(dev), jbuf, sizeof jbuf,
 			q_id, ublksrv_gettid());
+	ublksrv_tgt_store_dev_data(dev, jbuf);
 	pthread_mutex_unlock(&jbuf_lock);
 	q = ublksrv_queue_init(dev, q_id, NULL);
 	if (!q) {
@@ -233,6 +234,7 @@ int main(int argc, char *argv[])
 		.tgt_type = "demo_null",
 		.tgt_ops = &demo_tgt_type,
 		.flags = 0,
+		.run_dir = UBLKSRV_PID_DIR,
 	};
 	struct ublksrv_ctrl_dev *dev;
 	int ret;

--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -30,6 +30,8 @@ extern "C" {
 #define	DEF_QD		128
 #define	DEF_BUF_SIZE	(512 << 10)
 
+#define JSON_OFFSET   32
+
 /************ stored in ublksrv_ctrl_dev_info->ublksrv_flags *******/
 /*
  * target may not use io_uring for handling io, so eventfd is required
@@ -618,6 +620,20 @@ extern int ublksrv_dev_get_cq_depth(struct ublksrv_dev *dev);
  */
 extern void ublksrv_apply_oom_protection(void);
 
+/**
+ *
+ * Store the device json in the pidfile
+ */
+extern int ublksrv_tgt_store_dev_data(const struct ublksrv_dev *dev,
+				      const char *buf);
+
+/**
+ *
+ * Read the device json from the pid file
+ */
+extern char *ublksrv_tgt_get_dev_data(struct ublksrv_ctrl_dev *cdev);
+  
+  
 /** @} */ // end of ublksrv_dev group
 
 /* target json has to include the following key/value */

--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -31,6 +31,7 @@ extern "C" {
 #define	DEF_BUF_SIZE	(512 << 10)
 
 #define JSON_OFFSET   32
+#define UBLKSRV_PID_DIR  "/tmp/ublksrvd"
 
 /************ stored in ublksrv_ctrl_dev_info->ublksrv_flags *******/
 /*

--- a/include/ublksrv_tgt.h
+++ b/include/ublksrv_tgt.h
@@ -35,7 +35,6 @@ static inline unsigned ilog2(unsigned x)
 }
 
 #define MAX_NR_UBLK_DEVS	128
-#define UBLKSRV_PID_DIR  "/tmp/ublksrvd"
 
 /* json device data is stored at this offset of pid file */
 #define JSON_OFFSET   32

--- a/lib/ublksrv.c
+++ b/lib/ublksrv.c
@@ -1047,3 +1047,61 @@ int ublksrv_dev_get_cq_depth(struct ublksrv_dev *tdev)
 {
 	return tdev_to_local(tdev)->cq_depth;
 }
+
+int ublksrv_tgt_store_dev_data(const struct ublksrv_dev *dev,
+			       const char *buf)
+{
+	int ret;
+	int len = ublksrv_json_get_length(buf);
+	int fd = ublksrv_get_pidfile_fd(dev);
+
+	if (fd < 0) {
+		ublk_err( "fail to get fd of pid file, ret %d\n",
+				fd);
+		return fd;
+	}
+
+	ret = pwrite(fd, buf, len, JSON_OFFSET);
+	if (ret <= 0)
+		ublk_err( "fail to write json data to pid file, ret %d\n",
+				ret);
+
+	return ret;
+}
+
+char *ublksrv_tgt_get_dev_data(struct ublksrv_ctrl_dev *cdev)
+{
+	const struct ublksrv_ctrl_dev_info *info =
+		ublksrv_ctrl_get_dev_info(cdev);
+	int dev_id = info->dev_id;
+	struct stat st;
+	char pid_file[256];
+	char *buf;
+	int size, fd, ret;
+	const char *run_dir = ublksrv_ctrl_get_run_dir(cdev);
+
+	if (!run_dir)
+		return 0;
+
+	snprintf(pid_file, 256, "%s/%d.pid", run_dir, dev_id);
+	fd = open(pid_file, O_RDONLY);
+
+	if (fd <= 0)
+		return NULL;
+
+	if (fstat(fd, &st) < 0)
+		return NULL;
+
+	if (st.st_size <=  JSON_OFFSET)
+		return NULL;
+
+	size = st.st_size - JSON_OFFSET;
+	buf = (char *)malloc(size);
+	ret = pread(fd, buf, size, JSON_OFFSET);
+	if (ret <= 0)
+		fprintf(stderr, "fail to read json from %s ret %d\n",
+				pid_file, ret);
+	close(fd);
+
+	return buf;
+}

--- a/ublksrv_tgt.cpp
+++ b/ublksrv_tgt.cpp
@@ -271,64 +271,6 @@ char *ublksrv_tgt_realloc_json_buf(struct ublksrv_dev *dev, int *size)
 	return buf;
 }
 
-static int ublksrv_tgt_store_dev_data(const struct ublksrv_dev *dev,
-		const char *buf)
-{
-	int ret;
-	int len = ublksrv_json_get_length(buf);
-	int fd = ublksrv_get_pidfile_fd(dev);
-
-	if (fd < 0) {
-		ublk_err( "fail to get fd of pid file, ret %d\n",
-				fd);
-		return fd;
-	}
-
-	ret = pwrite(fd, buf, len, JSON_OFFSET);
-	if (ret <= 0)
-		ublk_err( "fail to write json data to pid file, ret %d\n",
-				ret);
-
-	return ret;
-}
-
-static char *ublksrv_tgt_get_dev_data(struct ublksrv_ctrl_dev *cdev)
-{
-	const struct ublksrv_ctrl_dev_info *info =
-		ublksrv_ctrl_get_dev_info(cdev);
-	int dev_id = info->dev_id;
-	struct stat st;
-	char pid_file[256];
-	char *buf;
-	int size, fd, ret;
-	const char *run_dir = ublksrv_ctrl_get_run_dir(cdev);
-
-	if (!run_dir)
-		return 0;
-
-	snprintf(pid_file, 256, "%s/%d.pid", run_dir, dev_id);
-	fd = open(pid_file, O_RDONLY);
-
-	if (fd <= 0)
-		return NULL;
-
-	if (fstat(fd, &st) < 0)
-		return NULL;
-
-	if (st.st_size <=  JSON_OFFSET)
-		return NULL;
-
-	size = st.st_size - JSON_OFFSET;
-	buf = (char *)malloc(size);
-	ret = pread(fd, buf, size, JSON_OFFSET);
-	if (ret <= 0)
-		fprintf(stderr, "fail to read json from %s ret %d\n",
-				pid_file, ret);
-	close(fd);
-
-	return buf;
-}
-
 static void *ublksrv_io_handler_fn(void *data)
 {
 	struct ublksrv_queue_info *info = (struct ublksrv_queue_info *)data;


### PR DESCRIPTION
This allows external targets, i.e. targets that are not spawned with 'ublk -t ...' the interface to specify the parameters shown when using 'ublk list [-v]' just like it does for internal targets.

Update demo_null to use this interface and store the parameters.
If this is a good approach, later I will convert demo_event the same way.

