### PR TITLE
tgt_loop: Introduce device offset

### DIFF
--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -712,7 +712,7 @@ extern int ublksrv_json_read_target_str_info(const char *jbuf, int len,
  * @param val field value with ulong type
  */
 extern int ublksrv_json_read_target_ulong_info(const char *jbuf,
-		const char *name, long *val);
+		const char *name, unsigned long *val);
 
 /**
  * Serialize json buffer from target field with string type

--- a/lib/ublksrv_json.cpp
+++ b/lib/ublksrv_json.cpp
@@ -171,7 +171,7 @@ int ublksrv_json_read_target_str_info(const char *jbuf, int len,
 }
 
 int ublksrv_json_read_target_ulong_info(const char *jbuf,
-		const char *name, long *val)
+		const char *name, unsigned long *val)
 {
 	json j;
 	std::string s;

--- a/nbd/tgt_nbd.cpp
+++ b/nbd/tgt_nbd.cpp
@@ -817,8 +817,9 @@ static int nbd_setup_tgt(struct ublksrv_dev *dev, int type, bool recovery,
 			exp_name);
 	ublksrv_json_read_target_ulong_info(jbuf, "send_zc", &send_zc);
 
-	NBD_HS_DBG("%s: host %s unix %s exp_name %s send_zc\n", __func__,
+	NBD_HS_DBG("%s: host %s unix %s exp_name %s send_zc: %ld\n", __func__,
 			host_name, unix_path, exp_name, send_zc);
+
 	for (i = 0; i < info->nr_hw_queues; i++) {
 		int sock;
 		unsigned int opts = 0;

--- a/nbd/tgt_nbd.cpp
+++ b/nbd/tgt_nbd.cpp
@@ -800,7 +800,7 @@ static int nbd_setup_tgt(struct ublksrv_dev *dev, int type, bool recovery,
 	char *tlshostname = NULL;
 	bool tls = false;
 
-	long send_zc = 0;
+	unsigned long send_zc = 0;
 
 
 	if (info->flags & UBLK_F_USER_COPY)
@@ -817,9 +817,8 @@ static int nbd_setup_tgt(struct ublksrv_dev *dev, int type, bool recovery,
 			exp_name);
 	ublksrv_json_read_target_ulong_info(jbuf, "send_zc", &send_zc);
 
-	NBD_HS_DBG("%s: host %s unix %s exp_name %s send_zc: %ld\n", __func__,
+	NBD_HS_DBG("%s: host %s unix %s exp_name %s send_zc: %lu\n", __func__,
 			host_name, unix_path, exp_name, send_zc);
-
 	for (i = 0; i < info->nr_hw_queues; i++) {
 		int sock;
 		unsigned int opts = 0;

--- a/tgt_loop.cpp
+++ b/tgt_loop.cpp
@@ -41,7 +41,7 @@ static int loop_setup_tgt(struct ublksrv_dev *dev, int type, bool recovery,
 	const struct ublksrv_ctrl_dev_info *info =
 		ublksrv_ctrl_get_dev_info(ublksrv_get_ctrl_dev(dev));
 	int fd, ret;
-	long direct_io = 0;
+	unsigned long direct_io = 0;
 	struct ublk_params p;
 	char file[PATH_MAX];
 


### PR DESCRIPTION
Just like `losetup` allows skipping first N bytes on the underlying file, let's have something similar for `tgt_loop`.