### PR TITLE
remove UBLKSRV_TGT_TYPE_* definitions

### DIFF
--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -292,7 +292,7 @@ struct ublksrv_tgt_type {
 	 */
 	void (*idle_fn)(const struct ublksrv_queue *q, bool enter);
 
-	/** target type */
+	/** Deprecated */
 	int  type;
 
 	/** flags required for ublk driver */

--- a/include/ublksrv_tgt.h
+++ b/include/ublksrv_tgt.h
@@ -115,19 +115,6 @@ static inline void ublksrv_tgt_set_io_data_size(struct ublksrv_tgt_info *tgt)
 
 //static_assert(sizeof(struct ublk_io_tgt) == sizeof(struct ublk_io), "ublk_io is defined as wrong");
 
-enum {
-	/* evaluate communication cost, ublksrv_null vs /dev/nullb0 */
-	UBLKSRV_TGT_TYPE_NULL,
-
-	/* ublksrv_loop vs. /dev/loop */
-	UBLKSRV_TGT_TYPE_LOOP,
-
-	UBLKSRV_TGT_TYPE_QCOW2,
-
-	UBLKSRV_TGT_TYPE_NBD,
-
-	UBLKSRV_TGT_TYPE_MAX = 256,
-};
 extern int ublksrv_register_tgt_type(struct ublksrv_tgt_type *type);
 extern void ublksrv_unregister_tgt_type(struct ublksrv_tgt_type *type);
 

--- a/nbd/ublk.nbd.cpp
+++ b/nbd/ublk.nbd.cpp
@@ -802,7 +802,6 @@ static int nbd_setup_tgt(struct ublksrv_dev *dev, int type, bool recovery,
 		return -EINVAL;
 
 	ublk_assert(jbuf);
-	ublk_assert(type == UBLKSRV_TGT_TYPE_NBD);
 
 	ublksrv_json_read_target_str_info(jbuf, NBD_MAX_NAME, "host",
 			host_name);
@@ -904,9 +903,7 @@ static int nbd_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 		ublksrv_ctrl_get_dev_info(ublksrv_get_ctrl_dev(dev));
 	int jbuf_size;
 	char *jbuf = ublksrv_tgt_return_json_buf(dev, &jbuf_size);
-	struct ublksrv_tgt_base_json tgt_json = {
-		.type = type,
-	};
+	struct ublksrv_tgt_base_json tgt_json = { 0 };
 	int opt;
 	int option_index = 0;
 	unsigned char bs_shift = 9;
@@ -921,9 +918,6 @@ static int nbd_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 		attrs |= UBLK_ATTR_READ_ONLY;
 
 	strcpy(tgt_json.name, "nbd");
-
-	if (type != UBLKSRV_TGT_TYPE_NBD)
-		return -1;
 
 	while ((opt = getopt_long(argc, argv, "-:f:",
 				  nbd_longopts, &option_index)) != -1) {
@@ -996,7 +990,6 @@ struct ublksrv_tgt_type  nbd_tgt_type = {
 	.handle_io_background = nbd_handle_io_bg,
 	.init_tgt = nbd_init_tgt,
 	.deinit_tgt = nbd_deinit_tgt,
-	.type	= UBLKSRV_TGT_TYPE_NBD,
 	.name	=  "nbd",
 	.recovery_tgt = nbd_recovery_tgt,
 	.init_queue = nbd_init_queue,

--- a/ublk.loop.cpp
+++ b/ublk.loop.cpp
@@ -118,8 +118,6 @@ static int loop_recovery_tgt(struct ublksrv_dev *dev, int type)
 	const struct ublksrv_ctrl_dev *cdev = ublksrv_get_ctrl_dev(dev);
 	const char *jbuf = ublksrv_ctrl_get_recovery_jbuf(cdev);
 
-	ublk_assert(type == UBLKSRV_TGT_TYPE_LOOP);
-
 	dev->tgt.tgt_data = calloc(sizeof(struct loop_tgt_data), 1);
 
 	return loop_setup_tgt(dev, type, true, jbuf);
@@ -143,9 +141,7 @@ static int loop_init_tgt(struct ublksrv_dev *dev, int type, int argc, char
 	char *file = NULL;
 	int jbuf_size;
 	char *jbuf;
-	struct ublksrv_tgt_base_json tgt_json = {
-		.type = type,
-	};
+	struct ublksrv_tgt_base_json tgt_json = { 0 };
 	struct ublk_params p = {
 		.types = UBLK_PARAM_TYPE_BASIC | UBLK_PARAM_TYPE_DISCARD,
 		.basic = {
@@ -165,9 +161,6 @@ static int loop_init_tgt(struct ublksrv_dev *dev, int type, int argc, char
 	unsigned long offset = 0;
 
 	strcpy(tgt_json.name, "loop");
-
-	if (type != UBLKSRV_TGT_TYPE_LOOP)
-		return -1;
 
 	while ((opt = getopt_long(argc, argv, "-:f:o:",
 				  lo_longopts, NULL)) != -1) {
@@ -487,7 +480,6 @@ struct ublksrv_tgt_type  loop_tgt_type = {
 	.tgt_io_done = loop_tgt_io_done,
 	.init_tgt = loop_init_tgt,
 	.deinit_tgt	=  loop_deinit_tgt,
-	.type	= UBLKSRV_TGT_TYPE_LOOP,
 	.name	=  "loop",
 	.recovery_tgt = loop_recovery_tgt,
 };

--- a/ublk.null.cpp
+++ b/ublk.null.cpp
@@ -12,9 +12,7 @@ static int null_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 		ublksrv_ctrl_get_dev_info(ublksrv_get_ctrl_dev(dev));
 	int jbuf_size;
 	char *jbuf = ublksrv_tgt_return_json_buf(dev, &jbuf_size);
-	struct ublksrv_tgt_base_json tgt_json = {
-		.type = type,
-	};
+	struct ublksrv_tgt_base_json tgt_json = { 0 };
 	unsigned long long dev_size = 250UL * 1024 * 1024 * 1024;
 	struct ublk_params p = {
 		.types = UBLK_PARAM_TYPE_BASIC,
@@ -29,9 +27,6 @@ static int null_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 	};
 
 	strcpy(tgt_json.name, "null");
-
-	if (type != UBLKSRV_TGT_TYPE_NULL)
-		return -1;
 
 	if (info->flags & UBLK_F_UNPRIVILEGED_DEV)
 		return -1;
@@ -59,7 +54,6 @@ static int null_recovery_tgt(struct ublksrv_dev *dev, int type)
 	struct ublk_params p;
 
 	ublk_assert(jbuf);
-	ublk_assert(type == UBLKSRV_TGT_TYPE_NULL);
 
 	ret = ublksrv_json_read_params(&p, jbuf);
 	if (ret) {
@@ -96,7 +90,6 @@ static int null_handle_io_async(const struct ublksrv_queue *q,
 struct ublksrv_tgt_type  null_tgt_type = {
 	.handle_io_async = null_handle_io_async,
 	.init_tgt = null_init_tgt,
-	.type	= UBLKSRV_TGT_TYPE_NULL,
 	.name	=  "null",
 	.recovery_tgt = null_recovery_tgt,
 };


### PR DESCRIPTION
There are now no built-in targets so we no longer need (struct ublksrv_tgt_type).usage_for_add