### PR TITLE
Target cleanup

### DIFF
--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -557,6 +557,20 @@ extern const char *ublksrv_ctrl_get_recovery_jbuf(const struct ublksrv_ctrl_dev 
 extern bool ublksrv_is_recovering(const struct ublksrv_ctrl_dev *ctrl_dev);
 
 /**
+ * Return private data
+ *
+ * @param dev the ublksrv control device instance
+ */
+extern void *ublksrv_ctrl_get_priv_data(const struct ublksrv_ctrl_dev *ctrl_dev);
+
+/**
+ * Store private data
+ *
+ * @param dev the ublksrv control device instance
+ */
+extern void ublksrv_ctrl_set_priv_data(struct ublksrv_ctrl_dev *dev, void *data);
+
+/**
  *
  * Store the device json in the pidfile
  */

--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -308,7 +308,9 @@ struct ublksrv_tgt_type {
 	/**
 	 * recovery callback for this target
 	 *
-	 * Required.
+	 * Obsolete!!!
+	 *
+	 * ->init_tgt() is preferred
 	 */
 	int (*recovery_tgt)(struct ublksrv_dev *, int type);
 
@@ -535,6 +537,11 @@ extern const char *ublksrv_ctrl_get_run_dir(const struct ublksrv_ctrl_dev *dev);
  * @param tgt_type target type name of this device
  * @param tgt_ops target type of this devie
  * @param recovery_jbuf points to device json buffer
+ *
+ * Obsolete!!!
+ *
+ * Recover status can be maintained by target code, `ublksrv_ctrl_dev`
+ * instance can be setup correctly via ublksrv_ctrl_init().
  */
 extern void ublksrv_ctrl_prep_recovery(struct ublksrv_ctrl_dev *dev,
 		const char *tgt_type, const struct ublksrv_tgt_type *tgt_ops,
@@ -546,6 +553,11 @@ extern void ublksrv_ctrl_prep_recovery(struct ublksrv_ctrl_dev *dev,
  * Setup target type, run_dir and json buffer before starting to recovery device.
  *
  * @param dev the ublksrv control device instance
+ *
+ * Obsolete!!!
+ *
+ * Target code can maintain json buffer by its private data via
+ * ublksrv_ctrl_get_priv_data() and ublksrv_ctrl_set_priv_data()
  */
 extern const char *ublksrv_ctrl_get_recovery_jbuf(const struct ublksrv_ctrl_dev *dev);
 
@@ -553,6 +565,11 @@ extern const char *ublksrv_ctrl_get_recovery_jbuf(const struct ublksrv_ctrl_dev 
  * Return true if this control device is for recovering
  *
  * @param dev the ublksrv control device instance
+ *
+ * Obsolete!!!
+ *
+ * Target code can maintain recovering status by its private data via
+ * ublksrv_ctrl_get_priv_data() and ublksrv_ctrl_set_priv_data()
  */
 extern bool ublksrv_is_recovering(const struct ublksrv_ctrl_dev *ctrl_dev);
 

--- a/include/ublksrv_priv.h
+++ b/include/ublksrv_priv.h
@@ -68,7 +68,8 @@ struct ublksrv_ctrl_dev {
 
 	cpu_set_t *queues_cpuset;
 
-	unsigned long reserved[4];
+	void *private_data;
+	unsigned long reserved[3];
 };
 
 struct ublk_io {

--- a/lib/ublksrv_cmd.c
+++ b/lib/ublksrv_cmd.c
@@ -619,3 +619,13 @@ const char *ublksrv_ctrl_get_recovery_jbuf(const struct ublksrv_ctrl_dev *dev)
 {
 	return dev->recovery_jbuf;
 }
+
+void *ublksrv_ctrl_get_priv_data(const struct ublksrv_ctrl_dev *dev)
+{
+	return dev->private_data;
+}
+
+void ublksrv_ctrl_set_priv_data(struct ublksrv_ctrl_dev *dev, void *data)
+{
+	dev->private_data = data;
+}

--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -187,4 +187,31 @@ int ublksrv_cmd_dev_add(struct ublksrv_tgt_type *tgt_type, int argc, char *argv[
 char *ublksrv_pop_cmd(int *argc, char *argv[]);
 int ublksrv_cmd_dev_user_recover(struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
 
+struct ublksrv_tgt_jbuf {
+	pthread_mutex_t lock;
+	int jbuf_size;
+	char *jbuf;
+};
+
+static inline void ublksrv_tgt_jbuf_exit(struct ublksrv_tgt_jbuf *jbuf)
+{
+	free(jbuf->jbuf);
+}
+
+static inline void ublksrv_tgt_jbuf_init(struct ublksrv_ctrl_dev *cdev,
+		struct ublksrv_tgt_jbuf *jbuf, bool recover)
+{
+	pthread_mutex_init(&jbuf->lock, NULL);
+	if (recover) {
+		jbuf->jbuf = ublksrv_tgt_get_dev_data(cdev);
+		if (jbuf->jbuf)
+			jbuf->jbuf_size = ublksrv_json_get_length(jbuf->jbuf);
+	} else {
+		jbuf->jbuf_size = 0;
+		jbuf->jbuf = NULL;
+	}
+}
+
+struct ublksrv_tgt_jbuf *ublksrv_tgt_get_jbuf(const struct ublksrv_ctrl_dev *cdev);
+
 #endif

--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -18,6 +18,7 @@
 #include <coroutine>
 #include <iostream>
 #include <type_traits>
+#include <semaphore.h>
 
 #include "ublksrv_utils.h"
 #include "ublksrv.h"
@@ -219,10 +220,26 @@ static inline void ublksrv_tgt_jbuf_init(struct ublksrv_ctrl_dev *cdev,
 		if (j->jbuf)
 			j->jbuf_size = ublksrv_json_get_length(j->jbuf);
 	} else {
+		j->jbuf = NULL;
+		j->jbuf_size = 0;
 		tgt_realloc_jbuf(j);
 	}
 }
 
 struct ublksrv_tgt_jbuf *ublksrv_tgt_get_jbuf(const struct ublksrv_ctrl_dev *cdev);
+
+struct ublksrv_ctrl_data {
+	struct ublksrv_tgt_jbuf jbuf;
+	sem_t queue_sem;
+	bool recover;
+};
+
+static inline struct ublksrv_ctrl_data *ublksrv_get_ctrl_data(const struct ublksrv_ctrl_dev *cdev)
+{
+	void *data = ublksrv_ctrl_get_priv_data(cdev);
+
+	return (struct ublksrv_ctrl_data *)data;
+}
+
 
 #endif

--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -169,10 +169,11 @@ static inline void ublk_get_sqe_pair(struct io_uring *r,
 		*sqe2 = io_uring_get_sqe(r);
 }
 
-int ublksrv_start_daemon(struct ublksrv_ctrl_dev *ctrl_dev);
+int ublksrv_start_daemon(struct ublksrv_ctrl_dev *ctrl_dev, int evtfd);
 int ublksrv_stop_io_daemon(const struct ublksrv_ctrl_dev *ctrl_dev);
 void ublksrv_tgt_set_params(struct ublksrv_ctrl_dev *cdev,
 			    const char *jbuf);
+int ublksrv_tgt_send_dev_event(int evtfd, int dev_id);
 
 struct ublksrv_queue_info {
 	const struct ublksrv_dev *dev;
@@ -180,7 +181,7 @@ struct ublksrv_queue_info {
 	pthread_t thread;
 };
 
-int ublksrv_parse_std_opts(struct ublksrv_dev_data *data, int argc, char *argv[]);
+int ublksrv_parse_std_opts(struct ublksrv_dev_data *data, int *efd, int argc, char *argv[]);
 void ublksrv_print_std_opts(void);
 int ublksrv_cmd_dev_add(struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
 char *ublksrv_pop_cmd(int *argc, char *argv[]);

--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -241,5 +241,11 @@ static inline struct ublksrv_ctrl_data *ublksrv_get_ctrl_data(const struct ublks
 	return (struct ublksrv_ctrl_data *)data;
 }
 
+static inline bool ublksrv_tgt_is_recovering(const struct ublksrv_ctrl_dev *cdev)
+{
+	struct ublksrv_ctrl_data *data = ublksrv_get_ctrl_data(cdev);
+
+	return data->recover;
+}
 
 #endif

--- a/targets/nbd/ublk.nbd.cpp
+++ b/targets/nbd/ublk.nbd.cpp
@@ -898,11 +898,11 @@ static int nbd_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 		{ "read_only",  0,  &read_only, 1},
 		{ NULL }
 	};
+	const struct ublksrv_ctrl_dev *cdev = ublksrv_get_ctrl_dev(dev);
 	struct ublksrv_tgt_info *tgt = &dev->tgt;
 	const struct ublksrv_ctrl_dev_info *info =
 		ublksrv_ctrl_get_dev_info(ublksrv_get_ctrl_dev(dev));
-	int jbuf_size;
-	char *jbuf = ublksrv_tgt_return_json_buf(dev, &jbuf_size);
+	struct ublksrv_tgt_jbuf *j = ublksrv_tgt_get_jbuf(cdev);
 	struct ublksrv_tgt_base_json tgt_json = { 0 };
 	int opt;
 	int option_index = 0;
@@ -939,20 +939,20 @@ static int nbd_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 		return -EINVAL;
 #endif
 
-	ublk_json_write_dev_info(dev, &jbuf, &jbuf_size);
-	ublk_json_write_tgt_str(dev, &jbuf, &jbuf_size, "host", host_name);
-	ublk_json_write_tgt_str(dev, &jbuf, &jbuf_size, "unix", unix_path);
-	ublk_json_write_tgt_str(dev, &jbuf, &jbuf_size, "export_name", exp_name);
-	ublk_json_write_tgt_long(dev, &jbuf, &jbuf_size, "send_zc", send_zc);
+	ublk_json_write_dev_info(dev, &j->jbuf, &j->jbuf_size);
+	ublk_json_write_tgt_str(dev, &j->jbuf, &j->jbuf_size, "host", host_name);
+	ublk_json_write_tgt_str(dev, &j->jbuf, &j->jbuf_size, "unix", unix_path);
+	ublk_json_write_tgt_str(dev, &j->jbuf, &j->jbuf_size, "export_name", exp_name);
+	ublk_json_write_tgt_long(dev, &j->jbuf, &j->jbuf_size, "send_zc", send_zc);
 
 	tgt->tgt_data = calloc(sizeof(struct nbd_tgt_data), 1);
 
-	ret = nbd_setup_tgt(dev, type, false, jbuf, &flags);
+	ret = nbd_setup_tgt(dev, type, false, j->jbuf, &flags);
 	if (ret)
 		return ret;
 
 	tgt_json.dev_size = tgt->dev_size;
-	ublk_json_write_target_base(dev, &jbuf, &jbuf_size, &tgt_json);
+	ublk_json_write_target_base(dev, &j->jbuf, &j->jbuf_size, &tgt_json);
 
 	struct ublk_params p = {
 		.types = UBLK_PARAM_TYPE_BASIC,
@@ -968,7 +968,7 @@ static int nbd_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 	};
 
 	nbd_parse_flags(&p, flags, 1U << bs_shift);
-	ublk_json_write_params(dev, &jbuf, &jbuf_size, &p);
+	ublk_json_write_params(dev, &j->jbuf, &j->jbuf_size, &p);
 
 	return 0;
 }
@@ -976,12 +976,15 @@ static int nbd_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 static int nbd_recovery_tgt(struct ublksrv_dev *dev, int type)
 {
 	const struct ublksrv_ctrl_dev *cdev = ublksrv_get_ctrl_dev(dev);
-	const char *jbuf = ublksrv_ctrl_get_recovery_jbuf(cdev);
+	struct ublksrv_tgt_jbuf *j = ublksrv_tgt_get_jbuf(cdev);
 	uint16_t flags = 0;
+
+	if (!j)
+		return -EINVAL;
 
 	dev->tgt.tgt_data = calloc(sizeof(struct nbd_tgt_data), 1);
 
-	return nbd_setup_tgt(dev, type, true, jbuf, &flags);
+	return nbd_setup_tgt(dev, type, true, j->jbuf, &flags);
 }
 
 struct ublksrv_tgt_type  nbd_tgt_type = {

--- a/targets/nbd/ublk.nbd.cpp
+++ b/targets/nbd/ublk.nbd.cpp
@@ -939,11 +939,11 @@ static int nbd_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 		return -EINVAL;
 #endif
 
-	ublk_json_write_dev_info(dev, &j->jbuf, &j->jbuf_size);
-	ublk_json_write_tgt_str(dev, &j->jbuf, &j->jbuf_size, "host", host_name);
-	ublk_json_write_tgt_str(dev, &j->jbuf, &j->jbuf_size, "unix", unix_path);
-	ublk_json_write_tgt_str(dev, &j->jbuf, &j->jbuf_size, "export_name", exp_name);
-	ublk_json_write_tgt_long(dev, &j->jbuf, &j->jbuf_size, "send_zc", send_zc);
+	ublk_json_write_dev_info(cdev);
+	ublk_json_write_tgt_str(cdev, "host", host_name);
+	ublk_json_write_tgt_str(cdev, "unix", unix_path);
+	ublk_json_write_tgt_str(cdev, "export_name", exp_name);
+	ublk_json_write_tgt_long(cdev, "send_zc", send_zc);
 
 	tgt->tgt_data = calloc(sizeof(struct nbd_tgt_data), 1);
 
@@ -952,7 +952,7 @@ static int nbd_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 		return ret;
 
 	tgt_json.dev_size = tgt->dev_size;
-	ublk_json_write_target_base(dev, &j->jbuf, &j->jbuf_size, &tgt_json);
+	ublk_json_write_target_base(cdev, &tgt_json);
 
 	struct ublk_params p = {
 		.types = UBLK_PARAM_TYPE_BASIC,
@@ -968,7 +968,7 @@ static int nbd_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 	};
 
 	nbd_parse_flags(&p, flags, 1U << bs_shift);
-	ublk_json_write_params(dev, &j->jbuf, &j->jbuf_size, &p);
+	ublk_json_write_params(cdev, &p);
 
 	return 0;
 }

--- a/targets/ublk.loop.cpp
+++ b/targets/ublk.loop.cpp
@@ -113,7 +113,7 @@ static int loop_setup_tgt(struct ublksrv_dev *dev, int type, bool recovery,
 	return 0;
 }
 
-static int loop_recovery_tgt(struct ublksrv_dev *dev, int type)
+static int loop_recover_tgt(struct ublksrv_dev *dev, int type)
 {
 	const struct ublksrv_ctrl_dev *cdev = ublksrv_get_ctrl_dev(dev);
 	struct ublksrv_tgt_jbuf *j = ublksrv_tgt_get_jbuf(cdev);
@@ -162,6 +162,9 @@ static int loop_init_tgt(struct ublksrv_dev *dev, int type, int argc, char
 	};
 	bool can_discard = false;
 	unsigned long offset = 0;
+
+	if (ublksrv_tgt_is_recovering(cdev))
+		return loop_recover_tgt(dev, 0);
 
 	strcpy(tgt_json.name, "loop");
 
@@ -483,7 +486,6 @@ struct ublksrv_tgt_type  loop_tgt_type = {
 	.init_tgt = loop_init_tgt,
 	.deinit_tgt	=  loop_deinit_tgt,
 	.name	=  "loop",
-	.recovery_tgt = loop_recovery_tgt,
 };
 
 

--- a/targets/ublk.loop.cpp
+++ b/targets/ublk.loop.cpp
@@ -241,12 +241,12 @@ static int loop_init_tgt(struct ublksrv_dev *dev, int type, int argc, char
 	else
 		p.types &= ~UBLK_PARAM_TYPE_DISCARD;
 
-	ublk_json_write_dev_info(dev, &j->jbuf, &j->jbuf_size);
-	ublk_json_write_target_base(dev, &j->jbuf, &j->jbuf_size, &tgt_json);
-	ublk_json_write_tgt_str(dev, &j->jbuf, &j->jbuf_size, "backing_file", file);
-	ublk_json_write_tgt_long(dev, &j->jbuf, &j->jbuf_size, "direct_io", !buffered_io);
-	ublk_json_write_tgt_ulong(dev, &j->jbuf, &j->jbuf_size, "offset", offset);
-	ublk_json_write_params(dev, &j->jbuf, &j->jbuf_size, &p);
+	ublk_json_write_dev_info(cdev);
+	ublk_json_write_target_base(cdev, &tgt_json);
+	ublk_json_write_tgt_str(cdev, "backing_file", file);
+	ublk_json_write_tgt_long(cdev, "direct_io", !buffered_io);
+	ublk_json_write_tgt_ulong(cdev, "offset", offset);
+	ublk_json_write_params(cdev, &p);
 
 	close(fd);
 

--- a/targets/ublk.null.cpp
+++ b/targets/ublk.null.cpp
@@ -10,7 +10,6 @@ static int null_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 	const struct ublksrv_ctrl_dev *cdev = ublksrv_get_ctrl_dev(dev);
 	const struct ublksrv_ctrl_dev_info *info = ublksrv_ctrl_get_dev_info(cdev);
 	struct ublksrv_tgt_info *tgt = &dev->tgt;
-	struct ublksrv_tgt_jbuf *j = ublksrv_tgt_get_jbuf(cdev);
 	struct ublksrv_tgt_base_json tgt_json = { 0 };
 	unsigned long long dev_size = 250UL * 1024 * 1024 * 1024;
 	struct ublk_params p = {
@@ -35,9 +34,9 @@ static int null_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 	tgt->nr_fds = 0;
 	ublksrv_tgt_set_io_data_size(tgt);
 
-	ublk_json_write_dev_info(dev, &j->jbuf, &j->jbuf_size);
-	ublk_json_write_target_base(dev, &j->jbuf, &j->jbuf_size, &tgt_json);
-	ublk_json_write_params(dev, &j->jbuf, &j->jbuf_size, &p);
+	ublk_json_write_dev_info(cdev);
+	ublk_json_write_target_base(cdev, &tgt_json);
+	ublk_json_write_params(cdev, &p);
 
 	return 0;
 }

--- a/targets/ublk.null.cpp
+++ b/targets/ublk.null.cpp
@@ -4,6 +4,8 @@
 
 #include "ublksrv_tgt.h"
 
+static int null_recover_tgt(struct ublksrv_dev *dev, int type);
+
 static int null_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 		char *argv[])
 {
@@ -24,6 +26,9 @@ static int null_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 		},
 	};
 
+	if (ublksrv_tgt_is_recovering(cdev))
+		return null_recover_tgt(dev, 0);
+
 	strcpy(tgt_json.name, "null");
 
 	if (info->flags & UBLK_F_UNPRIVILEGED_DEV)
@@ -41,7 +46,7 @@ static int null_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 	return 0;
 }
 
-static int null_recovery_tgt(struct ublksrv_dev *dev, int type)
+static int null_recover_tgt(struct ublksrv_dev *dev, int type)
 {
 	const struct ublksrv_ctrl_dev *cdev = ublksrv_get_ctrl_dev(dev);
 	struct ublksrv_tgt_jbuf *j = ublksrv_tgt_get_jbuf(cdev);
@@ -92,7 +97,6 @@ struct ublksrv_tgt_type  null_tgt_type = {
 	.handle_io_async = null_handle_io_async,
 	.init_tgt = null_init_tgt,
 	.name	=  "null",
-	.recovery_tgt = null_recovery_tgt,
 };
 
 

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -298,7 +298,7 @@ static int ublksrv_tgt_start_dev(struct ublksrv_ctrl_dev *cdev,
 	return 0;
 }
 
-static void ublksrv_io_handler(struct ublksrv_ctrl_dev *ctrl_dev, int evtfd, bool recover)
+static int ublksrv_io_handler(struct ublksrv_ctrl_dev *ctrl_dev, int evtfd, bool recover)
 {
 	struct ublksrv_ctrl_data cdata;
 	const struct ublksrv_ctrl_dev_info *dinfo =
@@ -307,7 +307,7 @@ static void ublksrv_io_handler(struct ublksrv_ctrl_dev *ctrl_dev, int evtfd, boo
 	char buf[32];
 	const struct ublksrv_dev *dev;
 	struct ublksrv_queue_info *info_array;
-	int i, ret;
+	int i, ret = -EINVAL;
 
 	ublksrv_ctrl_data_init(ctrl_dev, &cdata, recover);
 
@@ -361,6 +361,8 @@ out:
 	ublk_log("end ublksrv io daemon");
 	ublksrv_ctrl_data_exit(ctrl_dev, &cdata);
 	closelog();
+
+	return ret;
 }
 
 /* Not called from ublksrv daemon */
@@ -440,9 +442,7 @@ int ublksrv_start_daemon(struct ublksrv_ctrl_dev *ctrl_dev, int evtfd, bool reco
 		return ret;
 	}
 
-	ublksrv_io_handler(ctrl_dev, evtfd, recover);
-
-	return 0;
+	return ublksrv_io_handler(ctrl_dev, evtfd, recover);
 }
 
 //todo: resolve stack usage warning for mkpath/__mkpath

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -15,128 +15,114 @@ struct ublksrv_tgt_jbuf *ublksrv_tgt_get_jbuf(const struct ublksrv_ctrl_dev *cde
 	return &jbuf;
 }
 
-int ublk_json_write_dev_info(struct ublksrv_dev *dev, char **jbuf, int *len)
+int ublk_json_write_dev_info(const struct ublksrv_ctrl_dev *cdev)
 {
+	struct ublksrv_tgt_jbuf *j = ublksrv_tgt_get_jbuf(cdev);
 	int ret = 0;
 
+	if (!j)
+		return -EINVAL;
+
+	pthread_mutex_lock(&j->lock);
 	do {
-		ret = ublksrv_json_write_dev_info(ublksrv_get_ctrl_dev(dev),
-				*jbuf, *len);
-		if (ret < 0)
-			*jbuf = ublksrv_tgt_realloc_json_buf(dev, len);
-	} while (ret < 0);
+		ret = ublksrv_json_write_dev_info(cdev,
+				j->jbuf, j->jbuf_size);
+	} while (ret < 0 && tgt_realloc_jbuf(j));
+	pthread_mutex_unlock(&j->lock);
 
 	return ret;
 }
 
-int ublk_json_write_params(struct ublksrv_dev *dev, char **jbuf, int *len,
+int ublk_json_write_params(const struct ublksrv_ctrl_dev *cdev,
 		const struct ublk_params *p)
 {
+	struct ublksrv_tgt_jbuf *j = ublksrv_tgt_get_jbuf(cdev);
 	int ret = 0;
 
+	if (!j)
+		return -EINVAL;
+
+	pthread_mutex_lock(&j->lock);
 	do {
-		ret = ublksrv_json_write_params(p, *jbuf, *len);
-		if (ret < 0)
-			*jbuf = ublksrv_tgt_realloc_json_buf(dev, len);
-	} while (ret < 0);
+		ret = ublksrv_json_write_params(p, j->jbuf, j->jbuf_size);
+	} while (ret < 0 && tgt_realloc_jbuf(j));
+	pthread_mutex_unlock(&j->lock);
 
 	return ret;
 }
 
-int ublk_json_write_target_base(struct ublksrv_dev *dev, char **jbuf, int *len,
+int ublk_json_write_target_base(const struct ublksrv_ctrl_dev *cdev,
 		const struct ublksrv_tgt_base_json *tgt)
 {
+	struct ublksrv_tgt_jbuf *j = ublksrv_tgt_get_jbuf(cdev);
 	int ret = 0;
 
+	if (!j)
+		return -EINVAL;
+
+	pthread_mutex_lock(&j->lock);
 	do {
-		ret = ublksrv_json_write_target_base_info(*jbuf, *len, tgt);
-		if (ret < 0)
-			*jbuf = ublksrv_tgt_realloc_json_buf(dev, len);
-	} while (ret < 0);
+		ret = ublksrv_json_write_target_base_info(j->jbuf, j->jbuf_size, tgt);
+	} while (ret < 0 && tgt_realloc_jbuf(j));
+	pthread_mutex_unlock(&j->lock);
 
 	return ret;
 
 }
 
-int ublk_json_write_tgt_str(struct ublksrv_dev *dev, char **jbuf,
-		int *len, const char *name, const char *val)
+int ublk_json_write_tgt_str(const struct ublksrv_ctrl_dev *cdev, const char *name, const char *val)
 {
+	struct ublksrv_tgt_jbuf *j = ublksrv_tgt_get_jbuf(cdev);
 	int ret = 0;
 
+	if (!j)
+		return -EINVAL;
+
+	pthread_mutex_lock(&j->lock);
 	do {
 		if (val)
-			ret = ublksrv_json_write_target_str_info(*jbuf,
-				*len, name, val);
-
-		if (ret < 0)
-			*jbuf = ublksrv_tgt_realloc_json_buf(dev, len);
-	} while (ret < 0);
+			ret = ublksrv_json_write_target_str_info(j->jbuf,
+					j->jbuf_size, name, val);
+	} while (ret < 0 && tgt_realloc_jbuf(j));
+	pthread_mutex_unlock(&j->lock);
 
 	return ret;
 }
 
-int ublk_json_write_tgt_ulong(struct ublksrv_dev *dev, char **jbuf,
-		int *len, const char *name, unsigned long val)
+int ublk_json_write_tgt_ulong(const struct ublksrv_ctrl_dev *cdev, const char *name, unsigned long val)
 {
+	struct ublksrv_tgt_jbuf *j = ublksrv_tgt_get_jbuf(cdev);
 	int ret = 0;
 
+	if (!j)
+		return -EINVAL;
+
+	pthread_mutex_lock(&j->lock);
 	do {
-		ret = ublksrv_json_write_target_ulong_info(*jbuf,
-				*len, name, val);
-		if (ret < 0)
-			*jbuf = ublksrv_tgt_realloc_json_buf(dev, len);
-	} while (ret < 0);
+		ret = ublksrv_json_write_target_ulong_info(j->jbuf, j->jbuf_size,
+				name, val);
+	} while (ret < 0 && tgt_realloc_jbuf(j));
+	pthread_mutex_unlock(&j->lock);
 
 	return ret;
 }
 
-int ublk_json_write_tgt_long(struct ublksrv_dev *dev, char **jbuf,
-		int *len, const char *name, long val)
+int ublk_json_write_tgt_long(const struct ublksrv_ctrl_dev *cdev, const char *name, long val)
 {
+	struct ublksrv_tgt_jbuf *j = ublksrv_tgt_get_jbuf(cdev);
 	int ret = 0;
 
+	if (!j)
+		return -EINVAL;
+
+	pthread_mutex_lock(&j->lock);
 	do {
-		ret = ublksrv_json_write_target_long_info(*jbuf,
-				*len, name, val);
-		if (ret < 0)
-			*jbuf = ublksrv_tgt_realloc_json_buf(dev, len);
-	} while (ret < 0);
+		ret = ublksrv_json_write_target_long_info(j->jbuf, j->jbuf_size,
+				name, val);
+	} while (ret < 0 && tgt_realloc_jbuf(j));
+	pthread_mutex_unlock(&j->lock);
 
 	return ret;
-}
-
-char *__ublksrv_tgt_return_json_buf(struct ublksrv_dev *dev, int *size)
-{
-	if (jbuf.jbuf == NULL) {
-		jbuf.jbuf_size = 1024;
-		jbuf.jbuf = (char *)realloc((void *)jbuf.jbuf, jbuf.jbuf_size);
-	}
-	*size = jbuf.jbuf_size;
-
-	return jbuf.jbuf;
-}
-
-char *ublksrv_tgt_return_json_buf(struct ublksrv_dev *dev, int *size)
-{
-	char *buf;
-
-	pthread_mutex_lock(&jbuf.lock);
-	buf = __ublksrv_tgt_return_json_buf(dev, size);
-	pthread_mutex_unlock(&jbuf.lock);
-
-	return buf;
-}
-
-static char *__ublksrv_tgt_realloc_json_buf(struct ublksrv_tgt_jbuf *j)
-{
-	if (j->jbuf == NULL)
-		j->jbuf_size = 1024;
-	else
-		j->jbuf_size += 1024;
-
-	j->jbuf = (char *)realloc((void *)j->jbuf, j->jbuf_size);
-
-	return j->jbuf;
 }
 
 static int ublk_json_write_queue_info(const struct ublksrv_ctrl_dev *cdev,
@@ -149,32 +135,13 @@ static int ublk_json_write_queue_info(const struct ublksrv_ctrl_dev *cdev,
 		return -EINVAL;
 
 	pthread_mutex_lock(&j->lock);
-	if (!j->jbuf)
-		__ublksrv_tgt_realloc_json_buf(j);
 	do {
 		ret = ublksrv_json_write_queue_info(cdev, j->jbuf, j->jbuf_size,
 				qid, tid);
-		if (ret < 0)
-			__ublksrv_tgt_realloc_json_buf(j);
-	} while (ret < 0);
+	} while (ret < 0 && tgt_realloc_jbuf(j));
 	pthread_mutex_unlock(&j->lock);
 
 	return ret;
-}
-
-
-char *ublksrv_tgt_realloc_json_buf(struct ublksrv_dev *dev, int *size)
-{
-	const struct ublksrv_ctrl_dev *cdev = ublksrv_get_ctrl_dev(dev);
-	struct ublksrv_tgt_jbuf *j = ublksrv_tgt_get_jbuf(cdev);
-	char *buf;
-
-	pthread_mutex_lock(&jbuf.lock);
-	buf = __ublksrv_tgt_realloc_json_buf(j);
-	*size = j->jbuf_size;
-	pthread_mutex_unlock(&jbuf.lock);
-
-	return buf;
 }
 
 static void *ublksrv_io_handler_fn(void *data)

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -157,7 +157,7 @@ static int ublk_json_write_queue_info(const struct ublksrv_ctrl_dev *cdev,
 	return ret;
 }
 
-static void *ublksrv_io_handler_fn(void *data)
+static void *ublksrv_queue_handler(void *data)
 {
 	struct ublksrv_queue_info *info = (struct ublksrv_queue_info *)data;
 	const struct ublksrv_dev *dev = info->dev;
@@ -298,7 +298,7 @@ static int ublksrv_tgt_start_dev(struct ublksrv_ctrl_dev *cdev,
 	return 0;
 }
 
-static int ublksrv_io_handler(struct ublksrv_ctrl_dev *ctrl_dev, int evtfd, bool recover)
+static int ublksrv_device_handler(struct ublksrv_ctrl_dev *ctrl_dev, int evtfd, bool recover)
 {
 	struct ublksrv_ctrl_data cdata;
 	const struct ublksrv_ctrl_dev_info *dinfo =
@@ -335,7 +335,7 @@ static int ublksrv_io_handler(struct ublksrv_ctrl_dev *ctrl_dev, int evtfd, bool
 		info_array[i].dev = dev;
 		info_array[i].qid = i;
 		pthread_create(&info_array[i].thread, NULL,
-				ublksrv_io_handler_fn,
+				ublksrv_queue_handler,
 				&info_array[i]);
 	}
 
@@ -442,7 +442,7 @@ int ublksrv_start_daemon(struct ublksrv_ctrl_dev *ctrl_dev, int evtfd, bool reco
 		return ret;
 	}
 
-	return ublksrv_io_handler(ctrl_dev, evtfd, recover);
+	return ublksrv_device_handler(ctrl_dev, evtfd, recover);
 }
 
 //todo: resolve stack usage warning for mkpath/__mkpath

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -668,6 +668,8 @@ static int __cmd_dev_user_recover(struct ublksrv_tgt_type *tgt_type,
 {
 	struct ublksrv_dev_data data = {
 		.dev_id = number,
+		.tgt_type = tgt_type->name,
+		.tgt_ops = tgt_type,
 		.run_dir = ublksrv_get_pid_dir(),
 	};
 	struct ublksrv_ctrl_dev_info  dev_info;
@@ -729,7 +731,6 @@ static int __cmd_dev_user_recover(struct ublksrv_tgt_type *tgt_type,
 		goto fail;
 	}
 
-	ublksrv_ctrl_prep_recovery(dev, tgt_json.name, tgt_type, NULL);
 	ret = ublksrv_start_daemon(dev, evtfd, true);
 	if (ret < 0) {
 		fprintf(stderr, "start daemon %d failed\n", number);


### PR DESCRIPTION
 Simplifying & cleanup target implementation:

 - always run ublk.{target} executable in foreground, simplify ublk.{target} implementation a lot

 - ublk program is responsible for starting ublk.{target} in background, and communicating with ublk.target about device_id created in ublk.{target} via
 eventfd

 - cleanup the mess of json buffer handling

 - add two generic libublksrv APIs for getting/setting ublksrv_ctrl_dev private data

 - obsolete ->recover_tgt(), and three recovery related libublksrv APIs