### PR TITLE
 target cleanup #2: add ublksrv_tgt_cmd_main()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -274,17 +274,10 @@ Any kind of contribution is welcome!
 
 Development is done over github.
 
+Maillist
+========
 
-Todo:
-====
-
-libublk
-------
-
-Move libublksrv out of ublksrv project, and make it as one standalone repo
-and name it as libublk.
-
-It is planned to do it when ublk driver UAPI changes(feature addition) is slow down.
+A ublk mailing list is available at http://groups.google.com/group/ublk.
 
 License
 =======

--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -183,7 +183,7 @@ void ublksrv_print_std_opts(void);
 int ublksrv_cmd_dev_add(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
 char *ublksrv_pop_cmd(int *argc, char *argv[]);
 int ublksrv_cmd_dev_user_recover(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
-
+int ublksrv_tgt_cmd_main(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
 
 #define UBLK_TGT_MAX_JBUF_SZ 8192
 struct ublksrv_tgt_jbuf {

--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -180,9 +180,9 @@ struct ublksrv_queue_info {
 
 int ublksrv_parse_std_opts(struct ublksrv_dev_data *data, int *efd, int argc, char *argv[]);
 void ublksrv_print_std_opts(void);
-int ublksrv_cmd_dev_add(struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
+int ublksrv_cmd_dev_add(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
 char *ublksrv_pop_cmd(int *argc, char *argv[]);
-int ublksrv_cmd_dev_user_recover(struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
+int ublksrv_cmd_dev_user_recover(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
 
 
 #define UBLK_TGT_MAX_JBUF_SZ 8192

--- a/targets/nbd/ublk.nbd.cpp
+++ b/targets/nbd/ublk.nbd.cpp
@@ -1006,10 +1006,6 @@ static void cmd_usage(const char *name)
 	printf("ublk.%s add -t %s\n", name, name);
 	ublksrv_print_std_opts();
 	printf("\t--host=$HOST [--port=$PORT] | --unix=$UNIX_PATH\n");
-
-	printf("\n");
-	printf("ublk.%s restore -t %s\n", name, name);
-	printf("\t-n DEV_ID -v\n");
 }
 
 int main(int argc, char *argv[])

--- a/targets/nbd/ublk.nbd.cpp
+++ b/targets/nbd/ublk.nbd.cpp
@@ -990,10 +990,20 @@ static int nbd_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 	return 0;
 }
 
+static void nbd_cmd_usage()
+{
+	const char *name = "nbd";
+
+	printf("ublk.%s add -t %s\n", name, name);
+	ublksrv_print_std_opts();
+	printf("\t--host=$HOST [--port=$PORT] | --unix=$UNIX_PATH\n");
+}
+
 struct ublksrv_tgt_type  nbd_tgt_type = {
 	.handle_io_async = nbd_handle_io_async,
 	.tgt_io_done = nbd_tgt_io_done,
 	.handle_io_background = nbd_handle_io_bg,
+	.usage_for_add = nbd_cmd_usage,
 	.init_tgt = nbd_init_tgt,
 	.deinit_tgt = nbd_deinit_tgt,
 	.name	=  "nbd",
@@ -1001,42 +1011,7 @@ struct ublksrv_tgt_type  nbd_tgt_type = {
 	.deinit_queue = nbd_deinit_queue,
 };
 
-static void cmd_usage(const char *name)
-{
-	printf("ublk.%s add -t %s\n", name, name);
-	ublksrv_print_std_opts();
-	printf("\t--host=$HOST [--port=$PORT] | --unix=$UNIX_PATH\n");
-}
-
 int main(int argc, char *argv[])
 {
-	struct ublksrv_tgt_type *tgt_type = &nbd_tgt_type;
-	const char *cmd;
-	int ret;
-
-	setvbuf(stdout, NULL, _IOLBF, 0);
-
-	cmd = ublksrv_pop_cmd(&argc, argv);
-	if (cmd == NULL) {
-		printf("%s: missing command\n", argv[0]);
-		cmd_usage(tgt_type->name);
-		return EXIT_FAILURE;
-	}
-
-	if (!strcmp(cmd, "add"))
-		ret = ublksrv_cmd_dev_add(tgt_type, argc, argv);
-	else if (!strcmp(cmd, "recover"))
-		ret = ublksrv_cmd_dev_user_recover(tgt_type, argc, argv);
-	else if (!strcmp(cmd, "help") || !strcmp(cmd, "-h") || !strcmp(cmd, "--help")) {
-		cmd_usage(tgt_type->name);
-		ret = EXIT_SUCCESS;
-	} else {
-		fprintf(stderr, "unknown command: %s\n", cmd);
-		cmd_usage(tgt_type->name);
-		ret = EXIT_FAILURE;
-	}
-
-	ublk_ctrl_dbg(UBLK_DBG_CTRL_CMD, "cmd %s: result %d\n", cmd, ret);
-
-	return ret;
+	return ublksrv_tgt_cmd_main(&nbd_tgt_type, argc, argv);
 }

--- a/targets/nbd/ublk.nbd.cpp
+++ b/targets/nbd/ublk.nbd.cpp
@@ -999,7 +999,7 @@ static void nbd_cmd_usage()
 	printf("\t--host=$HOST [--port=$PORT] | --unix=$UNIX_PATH\n");
 }
 
-struct ublksrv_tgt_type  nbd_tgt_type = {
+static const struct ublksrv_tgt_type  nbd_tgt_type = {
 	.handle_io_async = nbd_handle_io_async,
 	.tgt_io_done = nbd_tgt_io_done,
 	.handle_io_background = nbd_handle_io_bg,

--- a/targets/ublk.loop.cpp
+++ b/targets/ublk.loop.cpp
@@ -496,10 +496,6 @@ static void cmd_usage(const char *name)
 	printf("\t-f backing_file [--buffered_io] [--offset NUM]\n");
 	printf("\t\tdefault is direct IO to backing file\n");
 	printf("\t\toffset skips first NUM sectors on backing file\n");
-
-	printf("\n");
-	printf("ublk.%s restore -t %s\n", name, name);
-	printf("\t-n DEV_ID -v\n");
 }
 
 int main(int argc, char *argv[])

--- a/targets/ublk.loop.cpp
+++ b/targets/ublk.loop.cpp
@@ -491,7 +491,7 @@ static void loop_cmd_usage()
 	printf("\t\toffset skips first NUM sectors on backing file\n");
 }
 
-struct ublksrv_tgt_type  loop_tgt_type = {
+static const struct ublksrv_tgt_type  loop_tgt_type = {
 	.handle_io_async = loop_handle_io_async,
 	.tgt_io_done = loop_tgt_io_done,
 	.usage_for_add = loop_cmd_usage,

--- a/targets/ublk.null.cpp
+++ b/targets/ublk.null.cpp
@@ -93,48 +93,23 @@ static int null_handle_io_async(const struct ublksrv_queue *q,
 	return 0;
 }
 
+static void null_cmd_usage()
+{
+	const char *name = "null";
+
+	printf("ublk.%s add -t %s\n", name, name);
+	ublksrv_print_std_opts();
+}
+
 struct ublksrv_tgt_type  null_tgt_type = {
 	.handle_io_async = null_handle_io_async,
+	.usage_for_add = null_cmd_usage,
 	.init_tgt = null_init_tgt,
 	.name	=  "null",
 };
 
 
-static void cmd_usage(const char *name)
-{
-	printf("ublk.%s add -t %s\n", name, name);
-	ublksrv_print_std_opts();
-}
-
 int main(int argc, char *argv[])
 {
-	struct ublksrv_tgt_type *tgt_type = &null_tgt_type;
-	const char *cmd;
-	int ret;
-
-	setvbuf(stdout, NULL, _IOLBF, 0);
-
-	cmd = ublksrv_pop_cmd(&argc, argv);
-	if (cmd == NULL) {
-		printf("%s: missing command\n", argv[0]);
-		cmd_usage(tgt_type->name);
-		return EXIT_FAILURE;
-	}
-
-	if (!strcmp(cmd, "add"))
-		ret = ublksrv_cmd_dev_add(tgt_type, argc, argv);
-	else if (!strcmp(cmd, "recover"))
-		ret = ublksrv_cmd_dev_user_recover(tgt_type, argc, argv);
-	else if (!strcmp(cmd, "help") || !strcmp(cmd, "-h") || !strcmp(cmd, "--help")) {
-		cmd_usage(tgt_type->name);
-		ret = EXIT_SUCCESS;
-	} else {
-		fprintf(stderr, "unknown command: %s\n", cmd);
-		cmd_usage(tgt_type->name);
-		ret = EXIT_FAILURE;
-	}
-
-	ublk_ctrl_dbg(UBLK_DBG_CTRL_CMD, "cmd %s: result %d\n", cmd, ret);
-
-	return ret;
+	return ublksrv_tgt_cmd_main(&null_tgt_type, argc, argv);
 }

--- a/targets/ublk.null.cpp
+++ b/targets/ublk.null.cpp
@@ -104,10 +104,6 @@ static void cmd_usage(const char *name)
 {
 	printf("ublk.%s add -t %s\n", name, name);
 	ublksrv_print_std_opts();
-
-	printf("\n");
-	printf("ublk.%s restore -t %s\n", name, name);
-	printf("\t-n DEV_ID -v\n");
 }
 
 int main(int argc, char *argv[])

--- a/targets/ublk.null.cpp
+++ b/targets/ublk.null.cpp
@@ -101,7 +101,7 @@ static void null_cmd_usage()
 	ublksrv_print_std_opts();
 }
 
-struct ublksrv_tgt_type  null_tgt_type = {
+static const struct ublksrv_tgt_type  null_tgt_type = {
 	.handle_io_async = null_handle_io_async,
 	.usage_for_add = null_cmd_usage,
 	.init_tgt = null_init_tgt,

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -592,7 +592,7 @@ void ublksrv_print_std_opts(void)
 	printf("\t--debug_mask=0x{DBG_MASK} --unprivileged\n\n");
 }
 
-int ublksrv_cmd_dev_add(struct ublksrv_tgt_type *tgt_type, int argc, char *argv[])
+int ublksrv_cmd_dev_add(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[])
 {
 	struct ublksrv_dev_data data = {0};
 	struct ublksrv_ctrl_dev *dev;
@@ -663,7 +663,7 @@ char *ublksrv_pop_cmd(int *argc, char *argv[])
 	return cmd;
 }
 
-static int __cmd_dev_user_recover(struct ublksrv_tgt_type *tgt_type,
+static int __cmd_dev_user_recover(const struct ublksrv_tgt_type *tgt_type,
 		int number, bool verbose, int evtfd)
 {
 	struct ublksrv_dev_data data = {
@@ -745,7 +745,7 @@ static int __cmd_dev_user_recover(struct ublksrv_tgt_type *tgt_type,
 	return ret;
 }
 
-int ublksrv_cmd_dev_user_recover(struct ublksrv_tgt_type *tgt_type, int argc, char *argv[])
+int ublksrv_cmd_dev_user_recover(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[])
 {
 	static const struct option longopts[] = {
 		{ "number",		0,	NULL, 'n' },


### PR DESCRIPTION
- add ublksrv_tgt_cmd_main() for all targets to share command line processing code

- other misc cleanup

- readme update

- fix target specific usage help