### PR TITLE
targets: remove --zero-copy/-z argument

### DIFF
--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -495,7 +495,6 @@ int ublksrv_parse_std_opts(struct ublksrv_dev_data *data, int *efd, int argc, ch
 		{ "number",		1,	NULL, 'n' },
 		{ "queues",		1,	NULL, 'q' },
 		{ "depth",		1,	NULL, 'd' },
-		{ "zero_copy",		1,	NULL, 'z' },
 		{ "uring_comp",		1,	NULL, 'u' },
 		{ "need_get_data",	1,	NULL, 'g' },
 		{ "user_recovery",	1,	NULL, 'r'},
@@ -515,7 +514,7 @@ int ublksrv_parse_std_opts(struct ublksrv_dev_data *data, int *efd, int argc, ch
 
 	mkpath(data->run_dir);
 
-	while ((opt = getopt_long(argc, argv, "-:t:n:d:q:u:g:r:e:i:z",
+	while ((opt = getopt_long(argc, argv, "-:t:n:d:q:u:g:r:e:i:",
 				  longopts, &option_index)) != -1) {
 		switch (opt) {
 		case 'n':


### PR DESCRIPTION
The zero copy feature in ublk driver side is still in-progress, and not completed yet, so remove the argument first. And we will add it back after the kernel side feature[1] is merged.

[1] https://lore.kernel.org/linux-block/20250218224229.837848-1-kbusch@meta.com/

That is also the reason why the help command doesn't show zero copy switch.