### PR TITLE
tests: try to populate lt-ublk.{target} first in test code

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -4,7 +4,11 @@
 DIR=$(cd "$(dirname "$0")";pwd)
 cd $DIR
 
-#. $DIR/common/fio_common
+# try to populate 'lt-ublk.{target}' first because 'lt-' prefix for
+# 'ulbk.{target}' may be required
+for UBLKT in `ls $DIR/../ublk.*`; do
+	$UBLKT help  > /dev/null 2>&1
+done
 
 : ${UBLK:=${DIR}/../ublk}
 if ! command -v "${UBLK}" &> /dev/null; then


### PR DESCRIPTION
The test code runs the executable from the top directory, which is actually one script, and finally 'lt-ublk' could be generated in .libs/, but 'lt-ublk.${target}' can't be generated in this way, and causes test failure, see issue github #102 when running ublk test on rhel10.

Fixes it by trying to populate 'lt-ublk.${target}' first by running 'ublk.{target} help' command.