### PR TITLE
tests: common: fix __ublk_get_dev_state()

### DIFF
--- a/tests/common/fio_common
+++ b/tests/common/fio_common
@@ -198,7 +198,7 @@ __ublk_get_dev_state() {
 	local dev_id=`__ublk_dev_id $dev`
 
 	eval $UBLK list -n ${dev_id} > ${UBLK_TMP}
-	state=`cat ${UBLK_TMP} | grep "state" | awk '{print $11}'`
+	state=`cat ${UBLK_TMP} | grep "state" | awk '{print $9}'`
 	echo $state
 }
 


### PR DESCRIPTION
commit b6aaf07 ("info: print the actual flag names for the device flags") changes 'state' position, so __ublk_get_dev_state() need to modify for adapting the change.

Fixes: b6aaf07 ("info: print the actual flag names for the device flags")