### PR TITLE
Don't exit from ublksrv_ctrl_init

### DIFF
--- a/lib/ublksrv_cmd.c
+++ b/lib/ublksrv_cmd.c
@@ -156,7 +156,8 @@ struct ublksrv_ctrl_dev *ublksrv_ctrl_init(struct ublksrv_dev_data *data)
 	dev->ctrl_fd = open(CTRL_DEV, O_RDWR);
 	if (dev->ctrl_fd < 0) {
 		fprintf(stderr, "control dev %s can't be opened: %m\n", CTRL_DEV);
-		exit(dev->ctrl_fd);
+		free(dev);
+		return NULL;
 	}
 
 	/* -1 means we ask ublk driver to allocate one free to us */

--- a/targets/ublk.cpp
+++ b/targets/ublk.cpp
@@ -214,6 +214,10 @@ static int list_one_dev(int number, bool log, bool verbose)
 		.run_dir = ublksrv_get_pid_dir(),
 	};
 	struct ublksrv_ctrl_dev *dev = ublksrv_ctrl_init(&data);
+	if (!dev) {
+		fprintf(stderr, "can't init dev %d\n", data.dev_id);
+		return -EOPNOTSUPP;
+	}
 	int ret;
 
 	if (!dev) {
@@ -288,6 +292,10 @@ static int cmd_dev_get_features(int argc, char *argv[])
 		.run_dir = ublksrv_get_pid_dir(),
 	};
 	struct ublksrv_ctrl_dev *dev = ublksrv_ctrl_init(&data);
+	if (!dev) {
+		fprintf(stderr, "can't init dev %d\n", data.dev_id);
+		return -EOPNOTSUPP;
+	}
 	__u64 features = 0;
 	int ret;
 	static const char *feat_map[] = {

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -595,7 +595,8 @@ static int ublksrv_cmd_dev_add(const struct ublksrv_tgt_type *tgt_type, int argc
 	dev = ublksrv_ctrl_init(&data);
 	if (!dev) {
 		fprintf(stderr, "can't init dev %d\n", data.dev_id);
-		return -EOPNOTSUPP;
+		ret = -EOPNOTSUPP;
+		goto fail_send_event;
 	}
 
 	ret = ublksrv_ctrl_add_dev(dev);
@@ -623,7 +624,7 @@ static int ublksrv_cmd_dev_add(const struct ublksrv_tgt_type *tgt_type, int argc
 	ublksrv_ctrl_del_dev(dev);
  fail:
 	ublksrv_ctrl_deinit(dev);
-
+ fail_send_event:
 	ublksrv_tgt_send_dev_event(evtfd, -1);
 
 	return ret;

--- a/utils/ublk_user_id.c
+++ b/utils/ublk_user_id.c
@@ -10,6 +10,10 @@ static int print_dev_owner_id(int number)
 		.dev_id = number,
 	};
 	struct ublksrv_ctrl_dev *dev = ublksrv_ctrl_init(&data);
+	if (!dev) {
+		fprintf(stderr, "can't init dev %d\n", data.dev_id);
+		return -EOPNOTSUPP;
+	}
 	int ret = ublksrv_ctrl_get_info(dev);
 
 	if (ret >= 0) {


### PR DESCRIPTION
ublksrv_ctrl_init can exit() if the ublk-control device can't be opened. This can cause ./ublk to wait indefinitely for the device_id to be written to the eventfd between ./ublk and the target program.

- Update ublksrv_ctrl_init to return NULL on all failures
- Update callers of ublksrv_ctrl_init to check if result is NULL.

Bug: #111 

This doesn't fix the general problem of #111 but does make ./ublk more robust