### PR TITLE
ublk_param_is_valid: remove upper limit of 4kb for blocksize

### DIFF
--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -142,7 +142,7 @@ static inline unsigned short ublk_unique_tag_to_tag(unsigned int unique_tag)
 
 static inline bool ublk_param_is_valid(const struct ublk_params *p)
 {
-	if (p->basic.logical_bs_shift < 9 || p->basic.physical_bs_shift > 12)
+	if (p->basic.logical_bs_shift < 9 || p->basic.logical_bs_shift > 12)
 		return false;
 	if (p->basic.logical_bs_shift > p->basic.physical_bs_shift)
 		return false;


### PR DESCRIPTION
Some filesystems and backing devices can report a st.st_blksize far bigger than 4kb which this limit ublk_param_is_valid prevents O_DIRECT from being  used.

Remove this limit to allow ublk.loop to use O_DIRECT for these scenarios.