### PR TITLE
ublk.cpp: do log error when deleting demo_* devices

### DIFF
--- a/targets/ublk.cpp
+++ b/targets/ublk.cpp
@@ -162,7 +162,7 @@ static int __cmd_dev_del(int number, bool log, bool async)
 		ret = ublksrv_ctrl_del_dev_async(dev);
 	else
 		ret = ublksrv_ctrl_del_dev(dev);
-	if (ret < 0) {
+	if (ret < 0 && ret != -ENODEV) {
 		fprintf(stderr, "delete dev %d failed %d\n", number, ret);
 		goto fail;
 	}


### PR DESCRIPTION
Treat ENODEV as success when deleting the control device. This stops "delete dev ? failed -19" to be printed everytime you delete a demo_* style device.