### PR TITLE
LOOP/NBD: remove recovery argument to the setup function

### DIFF
--- a/targets/nbd/ublk.nbd.cpp
+++ b/targets/nbd/ublk.nbd.cpp
@@ -756,7 +756,7 @@ static void nbd_deinit_tgt(const struct ublksrv_dev *dev)
 	}
 }
 
-static int nbd_setup_tgt(struct ublksrv_dev *dev, int type, bool recovery,
+static int nbd_setup_tgt(struct ublksrv_dev *dev, int type,
 		uint16_t *flags)
 {
 	struct ublksrv_tgt_info *tgt = &dev->tgt;
@@ -875,7 +875,7 @@ static int nbd_recover_tgt(struct ublksrv_dev *dev, int type)
 
 	dev->tgt.tgt_data = calloc(sizeof(struct nbd_tgt_data), 1);
 
-	return nbd_setup_tgt(dev, type, true, &flags);
+	return nbd_setup_tgt(dev, type, &flags);
 }
 
 static int nbd_init_tgt(struct ublksrv_dev *dev, int type, int argc,
@@ -942,7 +942,7 @@ static int nbd_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 
 	tgt->tgt_data = calloc(sizeof(struct nbd_tgt_data), 1);
 
-	ret = nbd_setup_tgt(dev, type, false, &flags);
+	ret = nbd_setup_tgt(dev, type, &flags);
 	if (ret)
 		return ret;
 

--- a/targets/ublk.loop.cpp
+++ b/targets/ublk.loop.cpp
@@ -38,7 +38,7 @@ static bool backing_supports_discard(char *name)
 	return false;
 }
 
-static int loop_setup_tgt(struct ublksrv_dev *dev, int type, bool recovery)
+static int loop_setup_tgt(struct ublksrv_dev *dev, int type)
 {
 	struct ublksrv_tgt_info *tgt = &dev->tgt;
 	const struct ublksrv_ctrl_dev *cdev = ublksrv_get_ctrl_dev(dev);
@@ -116,7 +116,7 @@ static int loop_recover_tgt(struct ublksrv_dev *dev, int type)
 {
 	dev->tgt.tgt_data = calloc(sizeof(struct loop_tgt_data), 1);
 
-	return loop_setup_tgt(dev, type, true);
+	return loop_setup_tgt(dev, type);
 }
 
 static int loop_init_tgt(struct ublksrv_dev *dev, int type, int argc, char
@@ -252,7 +252,7 @@ static int loop_init_tgt(struct ublksrv_dev *dev, int type, int argc, char
 
 	dev->tgt.tgt_data = calloc(sizeof(struct loop_tgt_data), 1);
 
-	return loop_setup_tgt(dev, type, false);
+	return loop_setup_tgt(dev, type);
 }
 
 static inline int loop_fallocate_mode(const struct ublksrv_io_desc *iod)


### PR DESCRIPTION
We no longer need to differentiate between setting up a target as a new device or recovering an existing device so this argument is no longer used by the setup function.

Remove the recovery argument.