### PR TITLE
Remove the direct use of ublksrv_print_std_opts from targets

### DIFF
--- a/targets/nbd/ublk.nbd.cpp
+++ b/targets/nbd/ublk.nbd.cpp
@@ -970,10 +970,6 @@ static int nbd_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 
 static void nbd_cmd_usage()
 {
-	const char *name = "nbd";
-
-	printf("ublk.%s add -t %s\n", name, name);
-	ublksrv_print_std_opts();
 	printf("\t--host=$HOST [--port=$PORT] | --unix=$UNIX_PATH\n");
 }
 

--- a/targets/ublk.loop.cpp
+++ b/targets/ublk.loop.cpp
@@ -530,10 +530,6 @@ static void loop_deinit_tgt(const struct ublksrv_dev *dev)
 
 static void loop_cmd_usage()
 {
-	const char *name = "loop";
-
-	printf("ublk.%s add -t %s\n", name, name);
-	ublksrv_print_std_opts();
 	printf("\t-f backing_file [--buffered_io] [--offset NUM]\n");
 	printf("\t\tdefault is direct IO to backing file\n");
 	printf("\t\toffset skips first NUM sectors on backing file\n");

--- a/targets/ublk.nfs.cpp
+++ b/targets/ublk.nfs.cpp
@@ -404,10 +404,6 @@ static int nfs_init_queue(const struct ublksrv_queue *q,
 
 static void nfs_cmd_usage()
 {
-	const char *name = "nfs";
-
-	printf("ublk.%s add -t %s\n", name, name);
-	ublksrv_print_std_opts();
 	printf("\t--nfs NFS-URL\n");
 }
 

--- a/targets/ublk.null.cpp
+++ b/targets/ublk.null.cpp
@@ -163,18 +163,9 @@ static void null_tgt_io_done(const struct ublksrv_queue *q,
 	ublksrv_tgt_io_done(q, data, cqe);
 }
 
-static void null_cmd_usage()
-{
-	const char *name = "null";
-
-	printf("ublk.%s add -t %s\n", name, name);
-	ublksrv_print_std_opts();
-}
-
 static const struct ublksrv_tgt_type  null_tgt_type = {
 	.handle_io_async = null_handle_io_async,
 	.tgt_io_done = null_tgt_io_done,
-	.usage_for_add = null_cmd_usage,
 	.init_tgt = null_init_tgt,
 	.name	=  "null",
 };

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -418,7 +418,7 @@ void ublksrv_print_std_opts(void)
 	printf("\t-n DEV_ID -q NR_HW_QUEUES -d QUEUE_DEPTH\n");
 	printf("\t-u URING_COMP -g NEED_GET_DATA -r USER_RECOVERY\n");
 	printf("\t-i USER_RECOVERY_REISSUE -e USER_RECOVERY_FAIL_IO\n");
-	printf("\t--debug_mask=0x{DBG_MASK} --unprivileged\n\n");
+	printf("\t--debug_mask=0x{DBG_MASK} --unprivileged\n");
 }
 
 static int ublksrv_cmd_dev_add(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[])
@@ -620,8 +620,12 @@ static int ublksrv_cmd_dev_user_recover(const struct ublksrv_tgt_type *tgt_type,
 
 static void cmd_usage(const struct ublksrv_tgt_type *tgt_type)
 {
+	printf("ublk.%s add -t %s\n", tgt_type->name, tgt_type->name);
+	ublksrv_print_std_opts();
 	if (tgt_type->usage_for_add)
 		tgt_type->usage_for_add();
+	printf("ublk.%s del -n DEV_ID\n", tgt_type->name);
+	printf("ublk.%s help -t %s\n", tgt_type->name, tgt_type->name);
 }
 
 int ublksrv_tgt_cmd_main(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[])


### PR DESCRIPTION
All built-in targets print the target-specific help via the call to the helper ublksrv_tgt_cmd_main()

This means that a target does not need to print the full set of all arguments but only those arguments that are unique for that particular target. Instead we can create the printout of all arguments inside ublksrv_tgt.cpp:cmd_usage() by combining the standard arguments that all ublksrv_tgt_cmd_main() consumers support and the extra arguments unique to this target.

This reduces some code duplication but also removes the need to access ublksrv_print_std_opts() and thus one less symbol needs to be accessed by a target.