### PR TITLE
NFS: remove call to ublksrv_tgt_set_io_data_size

### DIFF
--- a/targets/ublk.nfs.cpp
+++ b/targets/ublk.nfs.cpp
@@ -287,7 +287,6 @@ static int nfs_setup_tgt(struct ublksrv_dev *dev)
 	tgt->dev_size = p.basic.dev_sectors << 9;
 	tgt->tgt_ring_depth = info->queue_depth;
 	tgt->nr_fds = 0;
-	ublksrv_tgt_set_io_data_size(tgt);
 
 	return 0;
 }


### PR DESCRIPTION
We are not using "struct ublk_io_data.private_data" at all from this target so we do not need to allocate enough memory to store a "struct ublk_io_tgt" in this pointer like like the other targets do.