### PR TITLE
NFS: remove a spinlock around ublksrv_queue_handled_event()

### DIFF
--- a/targets/ublk.nfs.cpp
+++ b/targets/ublk.nfs.cpp
@@ -50,9 +50,7 @@ static void nfs_handle_event(const struct ublksrv_queue *q)
 		cb_data = tmp;
 	}
 
-	pthread_spin_lock(&q_data->io_list_lock);
 	ublksrv_queue_handled_event(q);
-	pthread_spin_unlock(&q_data->io_list_lock);
 }
 
 void rw_async_cb(int status, struct nfs_context *nfs,


### PR DESCRIPTION
We don't need this spinlock anymore.  It was used in early draft versions of the code but we no longer need it in the version committed.