### PR TITLE
Iscsi updates

### DIFF
--- a/doc/ublk.1
+++ b/doc/ublk.1
@@ -2,12 +2,12 @@
 .\"     Title: ublk
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 04/28/2025
+.\"      Date: 05/03/2025
 .\"    Manual: ublk: manage ublk devices
 .\"    Source: ublk
 .\"  Language: English
 .\"
-.TH "UBLK" "1" "04/28/2025" "ublk" "ublk: manage ublk devices"
+.TH "UBLK" "1" "05/03/2025" "ublk" "ublk: manage ublk devices"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -219,7 +219,7 @@ Example: Create a nfs block device
 .sp
 .SS "iSCSI"
 .PP
-Extra options for the iSCSI device type:
+Extra options for the iSCSI device type\&. iSCSI support requires libiscsi 1\&.20\&.1 or later\&.
 .PP
 \fB add \-t iscsi \&.\&.\&. \-\-iscsi ISCSI\-URL \-\-initiator\-name NAME \fR
 .PP

--- a/doc/ublk.1.xml
+++ b/doc/ublk.1.xml
@@ -310,7 +310,8 @@
 
 <refsect2><title>iSCSI</title>
 <para>
-  Extra options for the iSCSI device type:
+  Extra options for the iSCSI device type.
+  iSCSI support requires libiscsi 1.20.1 or later.
 </para>
 <para>
   <command>

--- a/lib/ublksrv_cmd.c
+++ b/lib/ublksrv_cmd.c
@@ -236,7 +236,7 @@ int ublksrv_ctrl_get_affinity(struct ublksrv_ctrl_dev *ctrl_dev)
 		path_len = 0;
 
 	len = (sizeof(cpu_set_t) + path_len) * ctrl_dev->dev_info.nr_hw_queues;
-	buf = malloc(len);
+	buf = calloc(1, len);
 
 	if (!buf)
 		return -ENOMEM;

--- a/lib/ublksrv_cmd.c
+++ b/lib/ublksrv_cmd.c
@@ -366,6 +366,8 @@ static int __ublksrv_ctrl_get_info_no_trans(struct ublksrv_ctrl_dev *dev,
 	};
 	bool has_dev_path = false;
 	int ret;
+	
+	memset(buf, 0, sizeof(buf));
 
 	if (ublk_is_unprivileged(dev) && _IOC_NR(data.cmd_op) == UBLK_CMD_GET_DEV_INFO)
 		return -EINVAL;
@@ -603,6 +605,8 @@ int ublksrv_ctrl_get_params(struct ublksrv_ctrl_dev *dev,
 	char buf[UBLKC_PATH_MAX + sizeof(*params)];
 	int ret;
 
+	memset(buf, 0, sizeof(buf));
+
 	params->len = sizeof(*params);
 
 	if (ublk_is_unprivileged(dev)) {
@@ -662,6 +666,8 @@ int ublksrv_ctrl_get_features(struct ublksrv_ctrl_dev *dev,
 		.len = sizeof(*features),
 	};
 
+	memset(features, 0, sizeof(*features));
+	
 	return __ublksrv_ctrl_cmd(dev, &data);
 }
 


### PR DESCRIPTION
Update the manpage to indicate we need version 1.20.1 of libiscsi for iscsi support.

Additionally, add a couple of patches to suppress valgrind hits. There are several places where we request data from the kernel
but valgrind has no way of knowing that this initializes the data and it causes valgrind to flag it as uninitialized data.
Fix this / suppress these warnings  by explicitely initializing the buffers before we pass it to the kernel for the kernel to populate.
