### PR TITLE
Fix regression in ublksrv_queue_init()

### DIFF
--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -1085,6 +1085,16 @@ extern const struct ublksrv_queue *ublksrv_queue_init(const struct ublksrv_dev *
 		unsigned short q_id, void *queue_data);
 
 /**
+ * Allocate and initialize ublksrv queue instance specifying queue flags
+ *
+ * @param dev the ublksrv device instance
+ * @param q_id queue id
+ * @param queue_data queue private data
+ */
+extern const struct ublksrv_queue *ublksrv_queue_init_flags(const struct ublksrv_dev *dev,
+		unsigned short q_id, void *queue_data, int flags);
+
+/**
  * Deinit & free ublksrv queue instance
  *
  * @param q the ublksrv queue instance

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -52,7 +52,8 @@ static void *ublksrv_queue_handler(void *data)
 
 	ublk_json_write_queue_info(cdev, q_id, ublksrv_gettid());
 
-	q = ublksrv_queue_init(dev, q_id, NULL);
+	q = ublksrv_queue_init_flags(dev, q_id, NULL, IORING_SETUP_COOP_TASKRUN |
+		IORING_SETUP_SINGLE_ISSUER | IORING_SETUP_DEFER_TASKRUN);
 	if (!q) {
 		ublk_err("ublk dev %d queue %d init queue failed",
 				dev_id, q_id);


### PR DESCRIPTION
61bd439dafa changed the parameters for the ring to add IORING_SETUP_SINGLE_ISSUER/IORING_SETUP_DEFER_TASKRUN.

But the ring is part of the public API and this can break applications that are not compatible with SINGLE_ISSUER.

Change this to restore ublksrv_queue_init() to the original flag used and create a new ublksrv_queue_init_flags() for applications that want to override/control what flags to use for the queue.

Update the built-in targets to use the flags
IORING_SETUP_COOP_TASKRUN | IORING_SETUP_SINGLE_ISSUER | IORING_SETUP_DEFER_TASKRUN