### PR TITLE
Harmonize help text

### DIFF
--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -159,7 +159,6 @@ static inline enum io_uring_op ublk_to_uring_fs_op(
 
 int ublksrv_tgt_send_dev_event(int evtfd, int dev_id);
 
-void ublksrv_print_std_opts(void);
 char *ublksrv_pop_cmd(int *argc, char *argv[]);
 int ublksrv_tgt_cmd_main(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
 

--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -160,7 +160,7 @@ static inline enum io_uring_op ublk_to_uring_fs_op(
 int ublksrv_tgt_send_dev_event(int evtfd, int dev_id);
 
 char *ublksrv_pop_cmd(int *argc, char *argv[]);
-int ublksrv_tgt_cmd_main(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
+int ublksrv_main(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
 
 static inline unsigned short ublk_cmd_op_nr(unsigned int op)
 {

--- a/targets/nbd/ublk.nbd.cpp
+++ b/targets/nbd/ublk.nbd.cpp
@@ -987,5 +987,5 @@ static const struct ublksrv_tgt_type  nbd_tgt_type = {
 
 int main(int argc, char *argv[])
 {
-	return ublksrv_tgt_cmd_main(&nbd_tgt_type, argc, argv);
+	return ublksrv_main(&nbd_tgt_type, argc, argv);
 }

--- a/targets/ublk.cpp
+++ b/targets/ublk.cpp
@@ -413,7 +413,7 @@ static int cmd_dev_help(int argc, char *argv[])
 	if (data.tgt_type == NULL) {
 		char *av[2] = { (char *)"ublk", (char *)"help"};
 
-		ublksrv_tgt_cmd_main(NULL, 2, av);
+		ublksrv_main(NULL, 2, av);
 		return EXIT_SUCCESS;
 	}
 

--- a/targets/ublk.iscsi.cpp
+++ b/targets/ublk.iscsi.cpp
@@ -539,5 +539,5 @@ static const struct ublksrv_tgt_type  iscsi_tgt_type = {
 
 int main(int argc, char *argv[])
 {
-	return ublksrv_tgt_cmd_main(&iscsi_tgt_type, argc, argv);
+	return ublksrv_main(&iscsi_tgt_type, argc, argv);
 }

--- a/targets/ublk.loop.cpp
+++ b/targets/ublk.loop.cpp
@@ -546,5 +546,5 @@ static const struct ublksrv_tgt_type  loop_tgt_type = {
 
 int main(int argc, char *argv[])
 {
-	return ublksrv_tgt_cmd_main(&loop_tgt_type, argc, argv);
+	return ublksrv_main(&loop_tgt_type, argc, argv);
 }

--- a/targets/ublk.nfs.cpp
+++ b/targets/ublk.nfs.cpp
@@ -414,5 +414,5 @@ static const struct ublksrv_tgt_type  nfs_tgt_type = {
 
 int main(int argc, char *argv[])
 {
-	return ublksrv_tgt_cmd_main(&nfs_tgt_type, argc, argv);
+	return ublksrv_main(&nfs_tgt_type, argc, argv);
 }

--- a/targets/ublk.null.cpp
+++ b/targets/ublk.null.cpp
@@ -173,5 +173,5 @@ static const struct ublksrv_tgt_type  null_tgt_type = {
 
 int main(int argc, char *argv[])
 {
-	return ublksrv_tgt_cmd_main(&null_tgt_type, argc, argv);
+	return ublksrv_main(&null_tgt_type, argc, argv);
 }

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -651,12 +651,23 @@ static int ublksrv_cmd_dev_user_recover(const struct ublksrv_tgt_type *tgt_type,
 
 static void cmd_usage(const struct ublksrv_tgt_type *tgt_type)
 {
-	printf("ublk.%s add -t %s\n", tgt_type->name, tgt_type->name);
+	const char *type = tgt_type ? tgt_type->name : "TYPE";
+
+	printf("ublk[.%s] add -t %s\n", type, type);
 	ublksrv_print_std_opts();
-	if (tgt_type->usage_for_add)
+	if (tgt_type && tgt_type->usage_for_add)
 		tgt_type->usage_for_add();
-	printf("ublk.%s del -n DEV_ID\n", tgt_type->name);
-	printf("ublk.%s help -t %s\n", tgt_type->name, tgt_type->name);
+	else {
+		printf("\tFor additional arguments specific to %s, run:\n", type);
+		printf("\t\tublk help -t %s\n", type);
+	}
+	printf("ublk[.%s] recover -n DEV_ID\n", type);
+	printf("ublk[.%s] help -t %s\n", type, type);
+	printf("ublk del -n DEV_ID [ -a | --all]\n");
+	printf("ublk list -n DEV_ID -v\n");
+	printf("ublk set_affinity -n DEV_ID -q QID --cpuset SET\n");
+	printf("ublk features\n");
+	printf("ublk -v | --version\n");
 }
 
 int ublksrv_tgt_cmd_main(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[])

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -670,7 +670,7 @@ static void cmd_usage(const struct ublksrv_tgt_type *tgt_type)
 	printf("ublk -v | --version\n");
 }
 
-int ublksrv_tgt_cmd_main(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[])
+int ublksrv_main(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[])
 {
 	const char *cmd;
 	int ret;

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -444,7 +444,7 @@ static int ublksrv_parse_add_opts(struct ublksrv_dev_data *data, int *efd, int a
 	return 0;
 }
 
-void ublksrv_print_std_opts(void)
+static void ublksrv_print_std_opts(void)
 {
 	printf("\t-n DEV_ID -q NR_HW_QUEUES -d QUEUE_DEPTH\n");
 	printf("\t-u URING_COMP -g NEED_GET_DATA -r USER_RECOVERY\n");


### PR DESCRIPTION
The help text was generated in two different places an was also inconsistent depending on what triggered the help text to be printed.
For example "ublk help" would print all the commands that the utility wrapper supported but none of the type specific arguments
while "ublk help -t TYPE | ublk.TYPE help" would print the type specific arguments but only list the three commands add/recover/help.

This series harmonizes this and moves all the help text generation into a single place and ensures that the help text is consistent
regardless of why we print the help text.

It additionally removes the need for ublksrv_print_std_opts() from being a semi-private function and makes it fully static to ublksrv_tgt.cpp.

Finally it renames ublksrv_tgt_cmd_main() to just ublksrv_main()