### PR TITLE
Make ublksrv_pop_cmd static

### DIFF
--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -159,7 +159,6 @@ static inline enum io_uring_op ublk_to_uring_fs_op(
 
 int ublksrv_tgt_send_dev_event(int evtfd, int dev_id);
 
-char *ublksrv_pop_cmd(int *argc, char *argv[]);
 int ublksrv_main(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
 
 static inline unsigned short ublk_cmd_op_nr(unsigned int op)

--- a/targets/ublk.cpp
+++ b/targets/ublk.cpp
@@ -463,9 +463,6 @@ int main(int argc, char *argv[])
 {
 	char *cmd;
 	int ret;
-	char exe[PATH_MAX];
-
-	strncpy(exe, argv[0], PATH_MAX - 1);
 
 	setvbuf(stdout, NULL, _IOLBF, 0);
 

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -522,7 +522,7 @@ static int ublksrv_cmd_dev_add(const struct ublksrv_tgt_type *tgt_type, int argc
 	return ret;
 }
 
-char *ublksrv_pop_cmd(int *argc, char *argv[])
+static char *ublksrv_pop_cmd(int *argc, char *argv[])
 {
 	char *cmd = argv[1];
 	if (*argc < 2) {


### PR DESCRIPTION
We do not need this function from the main ublk.cpp utility as we were basically just removing argv[1] and then just adding it back again before execv-ing the target specific binary.

This removes one symbol from the semi-private ublksrv_tgt.cpp
