### PR TITLE
Make ublksrv_tgt_send_dev_event static

### DIFF
--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -157,8 +157,6 @@ static inline enum io_uring_op ublk_to_uring_fs_op(
 	assert(0);
 }
 
-int ublksrv_tgt_send_dev_event(int evtfd, int dev_id);
-
 int ublksrv_main(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
 
 static inline unsigned short ublk_cmd_op_nr(unsigned int op)

--- a/targets/ublk.cpp
+++ b/targets/ublk.cpp
@@ -58,8 +58,6 @@ exec:
 
 		/* only reach here is execve failed */
 		fprintf(stderr, "Failed to execve() %s. %s\n", fp, strerror(errno));
-		if (pfd[1] >= 0)
-			ublksrv_tgt_send_dev_event(pfd[1], -1);
 		return -errno;
 	}
 

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -118,7 +118,7 @@ static void ublksrv_drain_fetch_commands(const struct ublksrv_dev *dev,
 		pthread_join(info[i].thread, &ret);
 }
 
-int ublksrv_tgt_send_dev_event(int evtfd, int dev_id)
+static int ublksrv_tgt_send_dev_event(int evtfd, int dev_id)
 {
 	uint64_t id;
 


### PR DESCRIPTION
We do not need to call this function with devid==-1 if execv fails because we already handle this failure if the file descriptor is just closed and the parentvprocess fails to read the dev_id from the pipe.

Thus make it static and reduce the size of the semi-private API in ublksrv_tgt.cpp.