### PR TITLE
Make ublksrv_main() a public function

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,33 +26,33 @@ if HAVE_LIBISCSI
 sbin_PROGRAMS += ublk.iscsi
 endif
 
-ublk_SOURCES = $(TGT_DIR)/ublk.cpp $(TGT_DIR)/ublksrv_tgt.cpp
+ublk_SOURCES = $(TGT_DIR)/ublk.cpp
 
 ublk_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
 ublk_CPPFLAGS = $(ublk_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
 ublk_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
 
-ublk_null_SOURCES = $(TGT_DIR)/ublk.null.cpp $(TGT_DIR)/ublksrv_tgt.cpp
+ublk_null_SOURCES = $(TGT_DIR)/ublk.null.cpp
 ublk_null_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
 ublk_null_CPPFLAGS = $(ublk_null_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
 ublk_null_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
 
-ublk_iscsi_SOURCES = $(TGT_DIR)/ublk.iscsi.cpp $(TGT_DIR)/ublksrv_tgt.cpp
+ublk_iscsi_SOURCES = $(TGT_DIR)/ublk.iscsi.cpp
 ublk_iscsi_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
 ublk_iscsi_CPPFLAGS = $(ublk_iscsi_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
 ublk_iscsi_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS) -liscsi
 
-ublk_loop_SOURCES = $(TGT_DIR)/ublk.loop.cpp $(TGT_DIR)/ublksrv_tgt.cpp
+ublk_loop_SOURCES = $(TGT_DIR)/ublk.loop.cpp
 ublk_loop_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
 ublk_loop_CPPFLAGS = $(ublk_loop_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
 ublk_loop_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
 
-ublk_nbd_SOURCES = $(TGT_DIR)/nbd/ublk.nbd.cpp $(TGT_DIR)/nbd/cliserv.c $(TGT_DIR)/nbd/nbd-client.c $(TGT_DIR)/ublksrv_tgt.cpp
+ublk_nbd_SOURCES = $(TGT_DIR)/nbd/ublk.nbd.cpp $(TGT_DIR)/nbd/cliserv.c $(TGT_DIR)/nbd/nbd-client.c
 ublk_nbd_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
 ublk_nbd_CPPFLAGS = $(ublk_nbd_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
 ublk_nbd_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
 
-ublk_nfs_SOURCES = $(TGT_DIR)/ublk.nfs.cpp $(TGT_DIR)/ublksrv_tgt.cpp
+ublk_nfs_SOURCES = $(TGT_DIR)/ublk.nfs.cpp
 ublk_nfs_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
 ublk_nfs_CPPFLAGS = $(ublk_nfs_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
 ublk_nfs_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS) -lnfs

--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -1158,6 +1158,8 @@ extern int ublksrv_queue_reap_events(const struct ublksrv_queue *tq);
 
 /** @} */ // end of ublksrv_queue group
 
+extern int ublksrv_main(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -5,6 +5,7 @@ lib_LTLIBRARIES = libublksrv.la
 libublksrv_la_SOURCES = \
 	ublksrv_cmd.c \
 	ublksrv_json.cpp \
+	ublksrv_main.cpp \
 	ublksrv.c \
 	utils.c \
 	ublksrv_aio.c

--- a/lib/ublksrv_main.cpp
+++ b/lib/ublksrv_main.cpp
@@ -1,8 +1,26 @@
 // SPDX-License-Identifier: MIT or GPL-2.0-only
 
 #include "config.h"
+#include <getopt.h>
+#include <limits.h>
+#include <pthread.h>
 #include <semaphore.h>
-#include "ublksrv_tgt.h"
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+
+#include <libgen.h>
+#include <coroutine>
+#include <iostream>
+#include <type_traits>
+#include <sched.h>
+
+#include "ublksrv_utils.h"
+#include "ublksrv.h"
 
 #define ERROR_EVTFD_DEVID   0xfffffffffffffffe
 

--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -157,8 +157,6 @@ static inline enum io_uring_op ublk_to_uring_fs_op(
 	assert(0);
 }
 
-int ublksrv_main(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[]);
-
 static inline unsigned short ublk_cmd_op_nr(unsigned int op)
 {
 	return _IOC_NR(op);


### PR DESCRIPTION
ublksrv_main() is the only remaining public symbol that is exported from targets/ublksrv_tgt.cpp. Move this whole file to lib/ and make this function part of the public API. This is the only externally visible symbol in the whole file.

Ublksrv_main() is mostly just boilerplate for creating a target and is hugely beneficial for both internal as well as out-of-tree targets. Make it a public function so that all targets can benefit from it and having to avoid duplicating the code.

As an example, both ublk.iscsi and ublk.nfs that use ublksrv_main(), in both cases ublksrv_main() and its dependencies is more boilerplate code that the iscsi/nfs code in ublk.[iscsi|nfs].cpp itself.


As a next step, removing this dependency should ralso emove the need for ublk.[iscsi|nfs].cpp from needing to include ublksrv_tgt.h which should possibly mean they no longer need to be C++ and can be changed to be plain C files.