### PR TITLE
iscsi: fix check for libiscsi

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -139,7 +139,7 @@ if test "x$with_libiscsi" != "xno"; then
 #include <stddef.h>
 #include <iscsi/iscsi.h>
 	]], [[
-		iscsi_mt_service_thread_start(NULL);
+		int (*ptr)(struct iscsi_context *) = iscsi_mt_service_thread_start;
 	]])],
 	[AC_MSG_RESULT([yes])
 	 AM_CONDITIONAL([HAVE_LIBISCSI], true)


### PR DESCRIPTION
libiscsi function check sometimes does not work

![image](https://github.com/user-attachments/assets/2dee145d-c4f6-424d-9f50-f2d128368388)

after fix:
![image](https://github.com/user-attachments/assets/72974ffd-0774-4a45-af64-f90cce19cfe2)
