### PR TITLE
Width fix for build_user_data

### DIFF
--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -352,7 +352,7 @@ static inline __u64 build_user_data(unsigned tag, unsigned op,
 {
 	assert(!(tag >> 16) && !(op >> 8) && !(tgt_data >> 16));
 
-	return tag | (op << 16) | (tgt_data << 24) | (__u64)is_target_io << 63;
+	return tag | (op << 16) | ((__u64)tgt_data << 24) | (__u64)is_target_io << 63;
 }
 
 static inline unsigned int user_data_to_tag(__u64 user_data)


### PR DESCRIPTION
tgt_data is a 16bit wide field but is being passed as a 32bit wide parameter which is then shifted left by 24bits causing the upper 8bits to fall off. First cast this to a 64bit value prior to shifting to preserve these bits for the usage by the target.

Addresses #156 