### PR TITLE
ublksrv_tgt: Add argument to control max_io_buf_bytes

### DIFF
--- a/doc/ublk.1
+++ b/doc/ublk.1
@@ -2,12 +2,12 @@
 .\"     Title: ublk
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 05/15/2025
+.\"      Date: 07/11/2025
 .\"    Manual: ublk: manage ublk devices
 .\"    Source: ublk
 .\"  Language: English
 .\"
-.TH "UBLK" "1" "05/15/2025" "ublk" "ublk: manage ublk devices"
+.TH "UBLK" "1" "07/11/2025" "ublk" "ublk: manage ublk devices"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -43,7 +43,7 @@ The following commands are supported:
 .PP
 Command to add a ublk device\&.
 .PP
-\fB add {\-t, \-\-type} TYPE [{\-n, \-\-number} DEV_ID] [{\-q, \-\-queues} NR_HW_QUEUES] [{\-d, \-\-depth} QUEUE_DEPTH] [{\-u, \-\-uring_comp} URING_COMP] [{\-g, \-\-need\-get\-data} NEED_GET_DATA] [{\-r, \-\-user_recovery} {0|1}] [{\-i, \-\-user_recovery_reissue} {0|1}] [{\-e, \-\-user_recovery_fail_io} {0|1}] [\-\-debug_mask=0x{DBG_MASK}] [\-\-unprivileged] [\-\-usercopy] [{\-z, \-\-zerocopy}] [<type specific options>] \fR
+\fB add {\-t, \-\-type} TYPE [{\-n, \-\-number} DEV_ID] [{\-q, \-\-queues} NR_HW_QUEUES] [{\-d, \-\-depth} QUEUE_DEPTH] [{\-u, \-\-uring_comp} URING_COMP] [{\-g, \-\-need\-get\-data} NEED_GET_DATA] [{\-r, \-\-user_recovery} {0|1}] [{\-i, \-\-user_recovery_reissue} {0|1}] [{\-e, \-\-user_recovery_fail_io} {0|1}] [\-\-debug_mask=0x{DBG_MASK}] [\-\-unprivileged] [\-\-usercopy] [\-\-max_io_buf_bytes={BYTES}] [{\-z, \-\-zerocopy}] [<type specific options>] \fR
 .PP
 \fB\-t, \-\-type\fR
 .RS 4
@@ -93,6 +93,13 @@ Block devices are recoverable if ublk server exits and restarts Outstanding I/O 
 \fB\-\-debug_mask\fR
 .RS 4
 Bitmask specifying which debug features to enable\&.
+.RE
+.PP
+\fB\-\-max_io_buf_bytes\fR
+.RS 4
+Maximum I/O size\&. Default is 512kb\&.
+.sp
+NOTE: Memory buffers are pre\-allocated with one buffer for each entry in queue_depth\&.
 .RE
 .PP
 \fB\-\-unprivileged\fR

--- a/doc/ublk.1.xml
+++ b/doc/ublk.1.xml
@@ -45,7 +45,7 @@
     [{-i, --user_recovery_reissue} {0|1}]
     [{-e, --user_recovery_fail_io} {0|1}]
     [--debug_mask=0x{DBG_MASK}] [--unprivileged]
-    [--usercopy]
+    [--usercopy] [--max_io_buf_bytes={BYTES}]
     [{-z, --zerocopy}]
     [&lt;type specific options&gt;]
   </command>
@@ -128,6 +128,16 @@
   <listitem>
     <para>
       Bitmask specifying which debug features to enable.
+    </para>
+  </listitem>
+  </varlistentry>
+  <varlistentry><term><option>--max_io_buf_bytes</option></term>
+  <listitem>
+    <para>
+      Maximum I/O size. Default is 512kb.
+    </para>
+    <para>
+      NOTE: Memory buffers are pre-allocated with one buffer for each entry in queue_depth.
     </para>
   </listitem>
   </varlistentry>

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -362,12 +362,14 @@ static int ublksrv_parse_add_opts(struct ublksrv_dev_data *data, int *efd, int a
 		{ "unprivileged",	0,	NULL, 0},
 		{ "usercopy",	0,	NULL, 0},
 		{ "eventfd",	1,	NULL, 0},
+		{ "max_io_buf_bytes",	1,	NULL, 0},
 		{ "zerocopy",	0,	NULL, 'z'},
 		{ NULL }
 	};
 
 	data->queue_depth = DEF_QD;
 	data->nr_hw_queues = DEF_NR_HW_QUEUES;
+	data->max_io_buf_bytes = DEF_BUF_SIZE;
 	data->dev_id = -1;
 	data->run_dir = ublksrv_get_pid_dir();
 
@@ -415,11 +417,12 @@ static int ublksrv_parse_add_opts(struct ublksrv_dev_data *data, int *efd, int a
 				data->flags |= UBLK_F_USER_COPY;
 			if (!strcmp(longopts[option_index].name, "eventfd") && efd)
 				*efd = strtol(optarg, NULL, 10);
+			if (!strcmp(longopts[option_index].name, "max_io_buf_bytes"))
+				data->max_io_buf_bytes = strtol(optarg, NULL, 10);
 			break;
 		}
 	}
 
-	data->max_io_buf_bytes = DEF_BUF_SIZE;
 	if (data->nr_hw_queues > MAX_NR_HW_QUEUES)
 		data->nr_hw_queues = MAX_NR_HW_QUEUES;
 	if (data->queue_depth > MAX_QD)


### PR DESCRIPTION
Add arguments to control the max buffer size for the ublksrv_tgt based targets.
Document this in the manpage.