### PR TITLE
libublksrv: dispatch CQEs reaped by an external ring owner

### DIFF
--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -1218,6 +1218,19 @@ extern void ublksrv_queue_dec_tgt_io_inflight(const struct ublksrv_queue *q);
  */
 extern int ublksrv_queue_reap_events(const struct ublksrv_queue *tq);
 
+/**
+ * Dispatch one CQE already reaped from this queue's externally shared ring.
+ *
+ * The external owner remains responsible for advancing the CQ ring. This is
+ * intended for setup and teardown phases in which another reactor temporarily
+ * owns reap but must return ublk command CQEs to libublksrv.
+ *
+ * @param tq the ublksrv queue instance
+ * @param cqe the CQE to dispatch
+ */
+extern int ublksrv_queue_handle_cqe(const struct ublksrv_queue *tq,
+				    const struct io_uring_cqe *cqe);
+
 /** @} */ // end of ublksrv_queue group
 
 typedef  void (*epoll_cb)(struct ublksrv_queue *q, int revents);

--- a/include/ublksrv_priv.h
+++ b/include/ublksrv_priv.h
@@ -177,6 +177,7 @@ struct _ublksrv_queue {
 
 	unsigned cmd_inflight, tgt_io_inflight;	//obsolete
 	unsigned state;
+	bool cqe_dispatching;
 
 	int epollfd;
 	struct epoll_cb_data *epoll_callbacks;

--- a/lib/ublksrv.c
+++ b/lib/ublksrv.c
@@ -757,6 +757,7 @@ const struct ublksrv_queue *ublksrv_queue_init_flags(const struct ublksrv_dev *t
 	q->io_cmd_buf = NULL;
 	q->cmd_inflight = 0;
 	q->tgt_io_inflight = 0;
+	q->cqe_dispatching = false;
 	q->tid = ublksrv_gettid();
 
 	cmd_buf_size = ublksrv_queue_cmd_buf_sz(q);
@@ -1103,12 +1104,18 @@ static void ublksrv_handle_cqe(struct io_uring *r,
 
 static int ublksrv_reap_events_uring(struct io_uring *r)
 {
+	struct _ublksrv_queue *q = container_of(r, struct _ublksrv_queue, ring);
 	struct io_uring_cqe *cqe;
 	unsigned head;
 	int count = 0;
 
+	if (q->cqe_dispatching)
+		return -EBUSY;
+
 	io_uring_for_each_cqe(r, head, cqe) {
+		q->cqe_dispatching = true;
 		ublksrv_handle_cqe(r, cqe, NULL);
+		q->cqe_dispatching = false;
 		count += 1;
 	}
 	io_uring_cq_advance(r, count);
@@ -1119,6 +1126,24 @@ static int ublksrv_reap_events_uring(struct io_uring *r)
 int ublksrv_queue_reap_events(const struct ublksrv_queue *tq)
 {
 	return ublksrv_reap_events_uring(&tq_to_local(tq)->ring);
+}
+
+int ublksrv_queue_handle_cqe(const struct ublksrv_queue *tq,
+			     const struct io_uring_cqe *cqe)
+{
+	struct _ublksrv_queue *q;
+
+	if (!tq || !cqe)
+		return -EINVAL;
+
+	q = tq_to_local(tq);
+	if (q->cqe_dispatching)
+		return -EBUSY;
+
+	q->cqe_dispatching = true;
+	ublksrv_handle_cqe(&q->ring, (struct io_uring_cqe *)cqe, NULL);
+	q->cqe_dispatching = false;
+	return 0;
 }
 
 static void ublksrv_queue_idle_enter(struct _ublksrv_queue *q)


### PR DESCRIPTION
When an application shares a queue's io_uring with libublksrv, an external ring owner may reap a ublk CQE while processing the shared completion queue.

Advancing that CQE without passing it through libublksrv skips the normal command dispatch and accounting. Calling `ublksrv_queue_reap_events()` is not suitable because the external owner remains responsible for CQ iteration and advancement.

Add `ublksrv_queue_handle_cqe()` to dispatch one CQE through the normal libublksrv path without advancing the completion queue. The caller remains responsible for advancing the CQ.

Also reject recursive CQE dispatch while a target callback is in progress.

